### PR TITLE
github: Run Ubuntu clang build as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,8 @@ jobs:
       - name: Build (Release)
         run: cmake --build build --parallel --config Release --target prosper
 
-  build-ubuntu:
-    name: Build (Ubuntu)
+  build-ubuntu-gcc:
+    name: Build (Ubuntu, gcc)
 
     strategy:
       fail-fast: true
@@ -72,6 +72,45 @@ jobs:
 
       - name: Configure (Release)
         run: cmake -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release
+
+      - name: Build (Release)
+        run: cmake --build build --target prosper
+
+  build-ubuntu-clang:
+    name: Build (Ubuntu, clang)
+
+    strategy:
+      fail-fast: true
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Get Cmake
+        uses: lukka/get-cmake@latest
+
+      - name: Get dependencies
+        run: sudo apt install xorg-dev clang-15
+
+      - name: Prepare Vulkan SDK
+        uses: humbletim/setup-vulkan-sdk@v1.2.0
+        with:
+          vulkan-query-version: 1.3.261.1
+          vulkan-components: Vulkan-Headers, Vulkan-Loader
+          vulkan-use-cache: true
+
+      - name: Configure (Debug)
+        run: CC=clang-15 CXX=clang++-15 cmake -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build (Debug)
+        run: cmake --build build --target prosper
+
+      - name: Configure (Release)
+        run: CC=clang-15 CXX=clang++-15 cmake -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release
 
       - name: Build (Release)
         run: cmake --build build --target prosper


### PR DESCRIPTION
Let's be safe even with clang-tidy running.