### PR TITLE
Wrap shared compute pass boilerplate in a utility class

### DIFF
--- a/include/CMakeLists.txt
+++ b/include/CMakeLists.txt
@@ -6,6 +6,7 @@ set(PROSPER_INCLUDE_DIR
 set(PROSPER_INCLUDES
     ${CMAKE_CURRENT_LIST_DIR}/App.hpp
     ${CMAKE_CURRENT_LIST_DIR}/Camera.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/ComputePass.hpp
     ${CMAKE_CURRENT_LIST_DIR}/Dds.hpp
     ${CMAKE_CURRENT_LIST_DIR}/DebugDrawTypes.hpp
     ${CMAKE_CURRENT_LIST_DIR}/DebugGeometry.hpp

--- a/include/ComputePass.hpp
+++ b/include/ComputePass.hpp
@@ -1,0 +1,206 @@
+#ifndef PROSPER_COMPUTE_PASS_HPP
+#define PROSPER_COMPUTE_PASS_HPP
+
+#include <wheels/allocators/scoped_scratch.hpp>
+#include <wheels/containers/optional.hpp>
+#include <wheels/containers/static_array.hpp>
+#include <wheels/containers/string.hpp>
+
+#include "Camera.hpp"
+#include "Device.hpp"
+#include "Profiler.hpp"
+#include "RenderResources.hpp"
+#include "Utils.hpp"
+
+class ComputePass
+{
+  public:
+    struct Shader
+    {
+        std::filesystem::path relPath;
+        wheels::String debugName;
+        wheels::Optional<wheels::String> defines;
+    };
+
+    template <typename Callback>
+    ComputePass(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        DescriptorAllocator *staticDescriptorsAlloc,
+        Callback &&shaderDefinitionCallback, uint32_t storageSetIndex = 0,
+        wheels::Span<const vk::DescriptorSetLayout> externalDsLayouts = {},
+        vk::ShaderStageFlags storageStageFlags =
+            vk::ShaderStageFlagBits::eCompute);
+
+    ~ComputePass();
+
+    ComputePass(const ComputePass &other) = delete;
+    ComputePass(ComputePass &&other) = delete;
+    ComputePass &operator=(const ComputePass &other) = delete;
+    ComputePass &operator=(ComputePass &&other) = delete;
+
+    template <typename Callback>
+    void recompileShader(
+        wheels::ScopedScratch scopeAlloc, Callback &&shaderDefinitionCallback,
+        wheels::Span<const vk::DescriptorSetLayout> externalDsLayouts = {});
+
+    template <size_t N>
+    void updateDescriptorSet(
+        uint32_t nextFrame,
+        wheels::StaticArray<DescriptorInfo, N> const &bindingInfos);
+
+    [[nodiscard]] vk::DescriptorSet storageSet(uint32_t nextFrame) const;
+    [[nodiscard]] vk::DescriptorSetLayout storageSetLayout() const;
+
+    void record(
+        vk::CommandBuffer cb, const glm::uvec3 &groups,
+        wheels::Span<const vk::DescriptorSet> descriptorSets) const;
+
+    template <typename PCBlock>
+    void record(
+        vk::CommandBuffer cb, const PCBlock &pcBlock, const glm::uvec3 &groups,
+        wheels::Span<const vk::DescriptorSet> descriptorSets) const;
+
+  private:
+    template <typename Callback>
+    [[nodiscard]] bool compileShader(
+        wheels::ScopedScratch scopeAlloc, Callback &&shaderDefinitionCallback);
+
+    void destroyPipelines();
+
+    void createDescriptorSets(
+        wheels::ScopedScratch scopeAlloc,
+        DescriptorAllocator *staticDescriptorsAlloc,
+        vk::ShaderStageFlags storageStageFlags);
+
+    void createPipeline(
+        wheels::ScopedScratch scopeAlloc,
+        wheels::Span<const vk::DescriptorSetLayout> externalDsLayouts = {});
+
+    Device *_device{nullptr};
+
+    vk::ShaderModule _shaderModule;
+    wheels::Optional<ShaderReflection> _shaderReflection;
+
+    vk::DescriptorSetLayout _storageSetLayout;
+    uint32_t _storageSetIndex{0xFFFFFFFF};
+    wheels::StaticArray<vk::DescriptorSet, MAX_FRAMES_IN_FLIGHT> _storageSets{
+        {}};
+
+    vk::PipelineLayout _pipelineLayout;
+    vk::Pipeline _pipeline;
+};
+
+template <typename Callback>
+ComputePass::ComputePass(
+    wheels::ScopedScratch scopeAlloc, Device *device,
+    DescriptorAllocator *staticDescriptorsAlloc,
+    Callback &&shaderDefinitionCallback, uint32_t storageSetIndex,
+    wheels::Span<const vk::DescriptorSetLayout> externalDsLayouts,
+    vk::ShaderStageFlags storageStageFlags)
+: _device{device}
+, _storageSetIndex{storageSetIndex}
+{
+    assert(staticDescriptorsAlloc != nullptr);
+    assert(
+        (_storageSetIndex == externalDsLayouts.size()) &&
+        "Implementation assumes that the pass storage set is the last set and "
+        "is placed right after the last external one");
+
+    printf("Creating ComputePass\n");
+    if (!compileShader(scopeAlloc.child_scope(), shaderDefinitionCallback))
+        throw std::runtime_error("Shader compilation failed");
+
+    createDescriptorSets(
+        scopeAlloc.child_scope(), staticDescriptorsAlloc, storageStageFlags);
+    createPipeline(scopeAlloc.child_scope(), externalDsLayouts);
+}
+
+template <typename Callback>
+void ComputePass::recompileShader(
+    wheels::ScopedScratch scopeAlloc, Callback &&shaderDefinitionCallback,
+    wheels::Span<const vk::DescriptorSetLayout> externalDsLayouts)
+{
+    if (compileShader(scopeAlloc.child_scope(), shaderDefinitionCallback))
+    {
+        destroyPipelines();
+        createPipeline(scopeAlloc.child_scope(), externalDsLayouts);
+    }
+}
+
+template <size_t N>
+void ComputePass::updateDescriptorSet(
+    uint32_t nextFrame,
+    wheels::StaticArray<DescriptorInfo, N> const &bindingInfos)
+{
+    // TODO:
+    // Don't update if resources are the same as before (for this DS index)?
+    // Have to compare against both extent and previous native handle?
+    const vk::DescriptorSet ds = _storageSets[nextFrame];
+
+    assert(_shaderReflection.has_value());
+    const wheels::StaticArray descriptorWrites =
+        _shaderReflection->generateDescriptorWrites(
+            _storageSetIndex, ds, bindingInfos);
+
+    _device->logical().updateDescriptorSets(
+        asserted_cast<uint32_t>(descriptorWrites.size()),
+        descriptorWrites.data(), 0, nullptr);
+}
+
+template <typename PCBlock>
+void ComputePass::record(
+    vk::CommandBuffer cb, const PCBlock &pcBlock, const glm::uvec3 &groups,
+    wheels::Span<const vk::DescriptorSet> descriptorSets) const
+{
+    assert(all(greaterThan(groups, glm::uvec3{0u})));
+    assert(_shaderReflection.has_value());
+    assert(sizeof(PCBlock) == _shaderReflection->pushConstantsBytesize());
+
+    cb.bindPipeline(vk::PipelineBindPoint::eCompute, _pipeline);
+
+    cb.bindDescriptorSets(
+        vk::PipelineBindPoint::eCompute, _pipelineLayout, 0, // firstSet
+        asserted_cast<uint32_t>(descriptorSets.size()), descriptorSets.data(),
+        0, nullptr);
+
+    cb.pushConstants(
+        _pipelineLayout, vk::ShaderStageFlagBits::eCompute, 0, sizeof(PCBlock),
+        &pcBlock);
+
+    cb.dispatch(groups.x, groups.y, groups.z);
+}
+
+template <typename Callback>
+bool ComputePass::compileShader(
+    wheels::ScopedScratch scopeAlloc, Callback &&shaderDefinitionCallback)
+{
+    Shader shader = shaderDefinitionCallback(scopeAlloc);
+
+    printf("Compiling %s\n", shader.debugName.c_str());
+
+    wheels::Optional<Device::ShaderCompileResult> compResult =
+        _device->compileShaderModule(
+            scopeAlloc.child_scope(),
+            Device::CompileShaderModuleArgs{
+                .relPath = shader.relPath,
+                .debugName = shader.debugName.c_str(),
+                .defines = shader.defines.has_value() ? *shader.defines
+                                                      : wheels::StrSpan{""},
+            });
+
+    if (compResult.has_value())
+    {
+        _device->logical().destroy(_shaderModule);
+
+        ShaderReflection &reflection = compResult->reflection;
+
+        _shaderModule = compResult->module;
+        _shaderReflection = WHEELS_MOV(reflection);
+
+        return true;
+    }
+
+    return false;
+}
+
+#endif // PROSPER_COMPUTE_PASS_HPP

--- a/include/DeferredShading.hpp
+++ b/include/DeferredShading.hpp
@@ -6,6 +6,7 @@
 #include <wheels/containers/static_array.hpp>
 
 #include "Camera.hpp"
+#include "ComputePass.hpp"
 #include "DebugDrawTypes.hpp"
 #include "Device.hpp"
 #include "GBufferRenderer.hpp"
@@ -36,7 +37,7 @@ class DeferredShading
         RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
         const InputDSLayouts &dsLayouts);
 
-    ~DeferredShading();
+    ~DeferredShading() = default;
 
     DeferredShading(const DeferredShading &other) = delete;
     DeferredShading(DeferredShading &&other) = delete;
@@ -61,40 +62,8 @@ class DeferredShading
         vk::CommandBuffer cb, const World &world, const Camera &cam,
         const Input &input, uint32_t nextFrame, Profiler *profiler);
 
-  private:
-    [[nodiscard]] bool compileShaders(
-        wheels::ScopedScratch scopeAlloc,
-        const World::DSLayouts &worldDSLayouts);
-
-    void recordBarriers(
-        vk::CommandBuffer cb, const Input &input, const Output &output) const;
-
-    void destroyPipelines();
-
-    void createDescriptorSets(
-        wheels::ScopedScratch scopeAlloc,
-        DescriptorAllocator *staticDescriptorsAlloc);
-    struct BoundImages
-    {
-        ImageHandle albedoRoughness;
-        ImageHandle normalMetalness;
-        ImageHandle depth;
-        ImageHandle illumination;
-    };
-    void updateDescriptorSet(uint32_t nextFrame, const BoundImages &images);
-    void createPipeline(const InputDSLayouts &dsLayouts);
-
-    Device *_device{nullptr};
     RenderResources *_resources{nullptr};
-
-    vk::ShaderModule _compSM;
-    wheels::Optional<ShaderReflection> _shaderReflection;
-
-    vk::DescriptorSetLayout _descriptorSetLayout;
-    wheels::StaticArray<vk::DescriptorSet, MAX_FRAMES_IN_FLIGHT>
-        _descriptorSets{{}};
-    vk::PipelineLayout _pipelineLayout;
-    vk::Pipeline _pipeline;
+    ComputePass _computePass;
 
     DrawType _drawType{DrawType::Default};
 };

--- a/include/DepthOfFieldCombine.hpp
+++ b/include/DepthOfFieldCombine.hpp
@@ -6,6 +6,7 @@
 #include <wheels/containers/static_array.hpp>
 
 #include "Camera.hpp"
+#include "ComputePass.hpp"
 #include "Device.hpp"
 #include "Profiler.hpp"
 #include "RenderResources.hpp"
@@ -22,7 +23,7 @@ class DepthOfFieldCombine
         RenderResources *resources,
         DescriptorAllocator *staticDescriptorsAlloc);
 
-    ~DepthOfFieldCombine();
+    ~DepthOfFieldCombine() = default;
 
     DepthOfFieldCombine(const DepthOfFieldCombine &other) = delete;
     DepthOfFieldCombine(DepthOfFieldCombine &&other) = delete;
@@ -49,29 +50,8 @@ class DepthOfFieldCombine
   private:
     [[nodiscard]] bool compileShaders(wheels::ScopedScratch scopeAlloc);
 
-    void recordBarriers(
-        vk::CommandBuffer cb, const Input &input, const Output &output) const;
-
-    void destroyPipelines();
-
-    void createDescriptorSets(
-        wheels::ScopedScratch scopeAlloc,
-        DescriptorAllocator *staticDescriptorsAlloc);
-    void updateDescriptorSet(
-        uint32_t nextFrame, const Input &input, const Output &output);
-    void createPipeline();
-
-    Device *_device{nullptr};
     RenderResources *_resources{nullptr};
-
-    vk::ShaderModule _shaderModule;
-    wheels::Optional<ShaderReflection> _shaderReflection;
-
-    vk::DescriptorSetLayout _descriptorSetLayout;
-    wheels::StaticArray<vk::DescriptorSet, MAX_FRAMES_IN_FLIGHT>
-        _descriptorSets{{}};
-    vk::PipelineLayout _pipelineLayout;
-    vk::Pipeline _pipeline;
+    ComputePass _computePass;
 };
 
 #endif // PROSPER_DEPTH_OF_FIELD_COMBINE_HPP

--- a/include/DepthOfFieldDilate.hpp
+++ b/include/DepthOfFieldDilate.hpp
@@ -5,6 +5,7 @@
 #include <wheels/containers/optional.hpp>
 #include <wheels/containers/static_array.hpp>
 
+#include "ComputePass.hpp"
 #include "Device.hpp"
 #include "Profiler.hpp"
 #include "RenderResources.hpp"
@@ -21,7 +22,7 @@ class DepthOfFieldDilate
         RenderResources *resources,
         DescriptorAllocator *staticDescriptorsAlloc);
 
-    ~DepthOfFieldDilate();
+    ~DepthOfFieldDilate() = default;
 
     DepthOfFieldDilate(const DepthOfFieldDilate &other) = delete;
     DepthOfFieldDilate(DepthOfFieldDilate &&other) = delete;
@@ -38,33 +39,8 @@ class DepthOfFieldDilate
         vk::CommandBuffer cb, ImageHandle tileMinMaxCoC, uint32_t nextFrame,
         Profiler *profiler);
 
-  private:
-    [[nodiscard]] bool compileShaders(wheels::ScopedScratch scopeAlloc);
-
-    void recordBarriers(
-        vk::CommandBuffer cb, ImageHandle tileMinMaxCoC,
-        const Output &output) const;
-
-    void destroyPipelines();
-
-    void createDescriptorSets(
-        wheels::ScopedScratch scopeAlloc,
-        DescriptorAllocator *staticDescriptorsAlloc);
-    void updateDescriptorSet(
-        uint32_t nextFrame, ImageHandle tileMinMaxCoC, const Output &output);
-    void createPipeline();
-
-    Device *_device{nullptr};
     RenderResources *_resources{nullptr};
-
-    vk::ShaderModule _compSM;
-    wheels::Optional<ShaderReflection> _shaderReflection;
-
-    vk::DescriptorSetLayout _descriptorSetLayout;
-    wheels::StaticArray<vk::DescriptorSet, MAX_FRAMES_IN_FLIGHT>
-        _descriptorSets{{}};
-    vk::PipelineLayout _pipelineLayout;
-    vk::Pipeline _pipeline;
+    ComputePass _computePass;
 };
 
 #endif // PROSPER_DEPTH_OF_FIELD_DILATE_HPP

--- a/include/DepthOfFieldFlatten.hpp
+++ b/include/DepthOfFieldFlatten.hpp
@@ -5,6 +5,7 @@
 #include <wheels/containers/optional.hpp>
 #include <wheels/containers/static_array.hpp>
 
+#include "ComputePass.hpp"
 #include "Device.hpp"
 #include "Profiler.hpp"
 #include "RenderResources.hpp"
@@ -21,7 +22,7 @@ class DepthOfFieldFlatten
         RenderResources *resources,
         DescriptorAllocator *staticDescriptorsAlloc);
 
-    ~DepthOfFieldFlatten();
+    ~DepthOfFieldFlatten() = default;
 
     DepthOfFieldFlatten(const DepthOfFieldFlatten &other) = delete;
     DepthOfFieldFlatten(DepthOfFieldFlatten &&other) = delete;
@@ -38,34 +39,8 @@ class DepthOfFieldFlatten
         vk::CommandBuffer cb, ImageHandle halfResCircleOfConfusion,
         uint32_t nextFrame, Profiler *profiler);
 
-  private:
-    [[nodiscard]] bool compileShaders(wheels::ScopedScratch scopeAlloc);
-
-    void recordBarriers(
-        vk::CommandBuffer cb, ImageHandle halfResCircleOfConfusion,
-        const Output &output) const;
-
-    void destroyPipelines();
-
-    void createDescriptorSets(
-        wheels::ScopedScratch scopeAlloc,
-        DescriptorAllocator *staticDescriptorsAlloc);
-    void updateDescriptorSet(
-        uint32_t nextFrame, ImageHandle halfResCircleOfConfusion,
-        const Output &output);
-    void createPipeline();
-
-    Device *_device{nullptr};
     RenderResources *_resources{nullptr};
-
-    vk::ShaderModule _compSM;
-    wheels::Optional<ShaderReflection> _shaderReflection;
-
-    vk::DescriptorSetLayout _descriptorSetLayout;
-    wheels::StaticArray<vk::DescriptorSet, MAX_FRAMES_IN_FLIGHT>
-        _descriptorSets{{}};
-    vk::PipelineLayout _pipelineLayout;
-    vk::Pipeline _pipeline;
+    ComputePass _computePass;
 };
 
 #endif // PROSPER_DEPTH_OF_FIELD_FLATTEN_HPP

--- a/include/DepthOfFieldGather.hpp
+++ b/include/DepthOfFieldGather.hpp
@@ -5,6 +5,7 @@
 #include <wheels/containers/static_array.hpp>
 
 #include "Camera.hpp"
+#include "ComputePass.hpp"
 #include "Device.hpp"
 #include "Profiler.hpp"
 #include "RenderResources.hpp"
@@ -28,7 +29,7 @@ class DepthOfFieldGather
         RenderResources *resources,
         DescriptorAllocator *staticDescriptorsAlloc);
 
-    ~DepthOfFieldGather();
+    ~DepthOfFieldGather() = default;
 
     DepthOfFieldGather(const DepthOfFieldGather &other) = delete;
     DepthOfFieldGather(DepthOfFieldGather &&other) = delete;
@@ -51,35 +52,10 @@ class DepthOfFieldGather
         vk::CommandBuffer cb, const Input &input, GatherType gatherType,
         uint32_t nextFrame, Profiler *profiler);
 
-  private:
-    [[nodiscard]] bool compileShaders(wheels::ScopedScratch scopeAlloc);
-
-    void recordBarriers(
-        vk::CommandBuffer cb, const Input &input, const Output &output) const;
-
-    void destroyPipelines();
-
-    void createDescriptorSets(
-        wheels::ScopedScratch scopeAlloc,
-        DescriptorAllocator *staticDescriptorsAlloc);
-    void updateDescriptorSet(
-        vk::DescriptorSet descriptorSet, GatherType gatherType,
-        const Input &input, const Output &output);
-    void createPipeline();
-
-    Device *_device{nullptr};
     RenderResources *_resources{nullptr};
 
-    wheels::StaticArray<vk::ShaderModule, GatherType_Count> _shaderModules{{}};
-    wheels::StaticArray<ShaderReflection, GatherType_Count> _shaderReflections;
-
-    vk::DescriptorSetLayout _descriptorSetLayout;
-    // Typedef so we can use capacity() as a template arg
-    using DescriptorSets = wheels::StaticArray<
-        vk::DescriptorSet, GatherType_Count * MAX_FRAMES_IN_FLIGHT>;
-    DescriptorSets _descriptorSets{{}};
-    vk::PipelineLayout _pipelineLayout;
-    wheels::StaticArray<vk::Pipeline, GatherType_Count> _pipelines;
+    ComputePass _backgroundPass;
+    ComputePass _foregroundPass;
 
     uint32_t _frameIndex{0};
 };

--- a/include/DepthOfFieldSetup.hpp
+++ b/include/DepthOfFieldSetup.hpp
@@ -6,6 +6,7 @@
 #include <wheels/containers/static_array.hpp>
 
 #include "Camera.hpp"
+#include "ComputePass.hpp"
 #include "Device.hpp"
 #include "Profiler.hpp"
 #include "RenderResources.hpp"
@@ -22,7 +23,7 @@ class DepthOfFieldSetup
         RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
         vk::DescriptorSetLayout camDsLayout);
 
-    ~DepthOfFieldSetup();
+    ~DepthOfFieldSetup() = default;
 
     DepthOfFieldSetup(const DepthOfFieldSetup &other) = delete;
     DepthOfFieldSetup(DepthOfFieldSetup &&other) = delete;
@@ -46,32 +47,8 @@ class DepthOfFieldSetup
         vk::CommandBuffer cb, const Camera &cam, const Input &input,
         uint32_t nextFrame, Profiler *profiler);
 
-  private:
-    [[nodiscard]] bool compileShaders(wheels::ScopedScratch scopeAlloc);
-
-    void recordBarriers(
-        vk::CommandBuffer cb, const Input &input, const Output &output) const;
-
-    void destroyPipelines();
-
-    void createDescriptorSets(
-        wheels::ScopedScratch scopeAlloc,
-        DescriptorAllocator *staticDescriptorsAlloc);
-    void updateDescriptorSet(
-        uint32_t nextFrame, const Input &input, const Output &output);
-    void createPipeline(vk::DescriptorSetLayout camDsLayout);
-
-    Device *_device{nullptr};
     RenderResources *_resources{nullptr};
-
-    vk::ShaderModule _compSM;
-    wheels::Optional<ShaderReflection> _shaderReflection;
-
-    vk::DescriptorSetLayout _descriptorSetLayout;
-    wheels::StaticArray<vk::DescriptorSet, MAX_FRAMES_IN_FLIGHT>
-        _descriptorSets{{}};
-    vk::PipelineLayout _pipelineLayout;
-    vk::Pipeline _pipeline;
+    ComputePass _computePass;
 };
 
 #endif // PROSPER_DEPTH_OF_FIELD_SETUP_HPP

--- a/include/LightClustering.hpp
+++ b/include/LightClustering.hpp
@@ -2,10 +2,10 @@
 #define PROSPER_LIGHT_CLUSTERING_HPP
 
 #include "Camera.hpp"
+#include "ComputePass.hpp"
 #include "Device.hpp"
 #include "Profiler.hpp"
 #include "RenderResources.hpp"
-#include "Swapchain.hpp"
 #include "World.hpp"
 
 #include <wheels/allocators/scoped_scratch.hpp>
@@ -26,7 +26,8 @@ class LightClustering
         RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
         vk::DescriptorSetLayout camDSLayout,
         const World::DSLayouts &worldDSLayouts);
-    ~LightClustering();
+
+    ~LightClustering() = default;
 
     LightClustering(const LightClustering &other) = delete;
     LightClustering(LightClustering &&other) = delete;
@@ -52,33 +53,10 @@ class LightClustering
         Profiler *profiler);
 
   private:
-    [[nodiscard]] bool compileShaders(wheels::ScopedScratch scopeAlloc);
-
-    void recordBarriers(vk::CommandBuffer cb, const Output &output) const;
-
-    void destroyPipeline();
-
     [[nodiscard]] Output createOutputs(const vk::Extent2D &renderExtent);
-    void createDescriptorSets(
-        wheels::ScopedScratch scopeAlloc,
-        DescriptorAllocator *staticDescriptorsAlloc);
-    void updateDescriptorSet(uint32_t nextFrame, Output &outputs);
-    void createPipeline(
-        vk::DescriptorSetLayout camDSLayout,
-        const World::DSLayouts &worldDSLayouts);
 
-    Device *_device{nullptr};
     RenderResources *_resources{nullptr};
-
-    vk::ShaderModule _compSM;
-    wheels::Optional<ShaderReflection> _shaderReflection;
-
-    vk::DescriptorSetLayout _descriptorSetLayout;
-    wheels::StaticArray<vk::DescriptorSet, MAX_FRAMES_IN_FLIGHT>
-        _descriptorSets{{}};
-
-    vk::PipelineLayout _pipelineLayout;
-    vk::Pipeline _pipeline;
+    ComputePass _computePass;
 };
 
 #endif // PROSPER_LIGHT_CLUSTERING_HPP

--- a/include/TextureDebug.hpp
+++ b/include/TextureDebug.hpp
@@ -5,6 +5,7 @@
 #include <wheels/containers/hash_map.hpp>
 #include <wheels/containers/static_array.hpp>
 
+#include "ComputePass.hpp"
 #include "Device.hpp"
 #include "Profiler.hpp"
 #include "RenderResources.hpp"
@@ -34,7 +35,8 @@ class TextureDebug
         wheels::Allocator &alloc, wheels::ScopedScratch scopeAlloc,
         Device *device, RenderResources *resources,
         DescriptorAllocator *staticDescriptorsAlloc);
-    ~TextureDebug();
+
+    ~TextureDebug() = default;
 
     TextureDebug(const TextureDebug &other) = delete;
     TextureDebug(TextureDebug &&other) = delete;
@@ -50,37 +52,11 @@ class TextureDebug
         Profiler *profiler);
 
   private:
-    bool compileShaders(wheels::ScopedScratch scopeAlloc);
-
-    void destroyPipelines();
-
-    void createDescriptorSets(
-        wheels::ScopedScratch scopeAlloc,
-        DescriptorAllocator *staticDescriptorsAlloc);
-    void createPipelines();
-
     ImageHandle createOutput(vk::Extent2D size);
 
-    struct BoundImages
-    {
-        ImageHandle inColor;
-        ImageHandle outColor;
-    };
-    void updateDescriptorSet(uint32_t nextFrame, const BoundImages &images);
-
-    void recordBarriers(vk::CommandBuffer cb, const BoundImages &images) const;
-
-    Device *_device{nullptr};
     RenderResources *_resources{nullptr};
 
-    vk::ShaderModule _compSM;
-    wheels::Optional<ShaderReflection> _shaderReflection;
-
-    vk::DescriptorSetLayout _descriptorSetLayout;
-    wheels::StaticArray<vk::DescriptorSet, MAX_FRAMES_IN_FLIGHT>
-        _descriptorSets{{}};
-    vk::PipelineLayout _pipelineLayout;
-    vk::Pipeline _pipeline;
+    ComputePass _computePass;
 
     struct TargetSettings
     {

--- a/include/ToneMap.hpp
+++ b/include/ToneMap.hpp
@@ -4,6 +4,7 @@
 #include <wheels/allocators/scoped_scratch.hpp>
 #include <wheels/containers/static_array.hpp>
 
+#include "ComputePass.hpp"
 #include "Device.hpp"
 #include "Profiler.hpp"
 #include "RenderResources.hpp"
@@ -17,7 +18,7 @@ class ToneMap
         wheels::ScopedScratch scopeAlloc, Device *device,
         RenderResources *resources,
         DescriptorAllocator *staticDescriptorsAlloc);
-    ~ToneMap();
+    ~ToneMap() = default;
 
     ToneMap(const ToneMap &other) = delete;
     ToneMap(ToneMap &&other) = delete;
@@ -37,39 +38,10 @@ class ToneMap
         Profiler *profiler);
 
   private:
-    bool compileShaders(wheels::ScopedScratch scopeAlloc);
-
-    void destroyPipelines();
-
-    void createOutputImage(const vk::Extent2D &renderExtent);
-    void createDescriptorSets(
-        wheels::ScopedScratch scopeAlloc,
-        DescriptorAllocator *staticDescriptorsAlloc);
-    void createPipelines();
-
     Output createOutputs(const vk::Extent2D &size);
 
-    struct BoundImages
-    {
-        ImageHandle inColor;
-        ImageHandle toneMapped;
-    };
-    void updateDescriptorSet(uint32_t nextFrame, const BoundImages &images);
-
-    void recordBarriers(vk::CommandBuffer cb, const BoundImages &images) const;
-
-    Device *_device{nullptr};
     RenderResources *_resources{nullptr};
-
-    vk::ShaderModule _compSM;
-    wheels::Optional<ShaderReflection> _shaderReflection;
-
-    vk::DescriptorSetLayout _descriptorSetLayout;
-    wheels::StaticArray<vk::DescriptorSet, MAX_FRAMES_IN_FLIGHT>
-        _descriptorSets{{}};
-    vk::PipelineLayout _pipelineLayout;
-    vk::Pipeline _pipeline;
-    vk::Extent2D _extent{};
+    ComputePass _computePass;
 
     float _exposure{1.f};
 };

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ set(PROSPER_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/App.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Camera.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Utils.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/ComputePass.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Dds.cpp
     ${CMAKE_CURRENT_LIST_DIR}/DebugGeometry.cpp
     ${CMAKE_CURRENT_LIST_DIR}/DebugRenderer.cpp

--- a/src/ComputePass.cpp
+++ b/src/ComputePass.cpp
@@ -1,0 +1,119 @@
+#include "ComputePass.hpp"
+
+#include <glm/glm.hpp>
+#include <imgui.h>
+
+#include "RenderTargets.hpp"
+#include "Utils.hpp"
+#include "VkUtils.hpp"
+
+using namespace glm;
+using namespace wheels;
+
+ComputePass::~ComputePass()
+{
+    if (_device != nullptr)
+    {
+        destroyPipelines();
+
+        _device->logical().destroy(_storageSetLayout);
+
+        _device->logical().destroy(_shaderModule);
+    }
+}
+
+vk::DescriptorSet ComputePass::storageSet(uint32_t nextFrame) const
+{
+    return _storageSets[nextFrame];
+}
+
+vk::DescriptorSetLayout ComputePass::storageSetLayout() const
+{
+    return _storageSetLayout;
+}
+
+void ComputePass::record(
+    vk::CommandBuffer cb, const uvec3 &groups,
+    Span<const vk::DescriptorSet> descriptorSets) const
+{
+    assert(all(greaterThan(groups, glm::uvec3{0u})));
+
+    cb.bindPipeline(vk::PipelineBindPoint::eCompute, _pipeline);
+
+    cb.bindDescriptorSets(
+        vk::PipelineBindPoint::eCompute, _pipelineLayout,
+        0, // firstSet
+        asserted_cast<uint32_t>(descriptorSets.size()), descriptorSets.data(),
+        0, nullptr);
+
+    cb.dispatch(groups.x, groups.y, groups.z);
+}
+
+void ComputePass::destroyPipelines()
+{
+    _device->logical().destroy(_pipeline);
+    _device->logical().destroy(_pipelineLayout);
+}
+
+void ComputePass::createDescriptorSets(
+    ScopedScratch scopeAlloc, DescriptorAllocator *staticDescriptorsAlloc,
+    vk::ShaderStageFlags storageStageFlags)
+{
+    assert(_shaderReflection.has_value());
+    const Array<vk::DescriptorSetLayoutBinding> layoutBindings =
+        _shaderReflection->generateLayoutBindings(
+            scopeAlloc, _storageSetIndex, storageStageFlags);
+
+    _storageSetLayout = _device->logical().createDescriptorSetLayout(
+        vk::DescriptorSetLayoutCreateInfo{
+            .bindingCount = asserted_cast<uint32_t>(layoutBindings.size()),
+            .pBindings = layoutBindings.data(),
+        });
+
+    const StaticArray<vk::DescriptorSetLayout, MAX_FRAMES_IN_FLIGHT> layouts{
+        _storageSetLayout};
+    staticDescriptorsAlloc->allocate(layouts, _storageSets);
+}
+
+void ComputePass::createPipeline(
+    wheels::ScopedScratch scopeAlloc,
+    Span<const vk::DescriptorSetLayout> externalDsLayouts)
+{
+    assert(_shaderReflection.has_value());
+
+    const vk::PushConstantRange pcRange{
+        .stageFlags = vk::ShaderStageFlagBits::eCompute,
+        .offset = 0,
+        .size = _shaderReflection->pushConstantsBytesize(),
+    };
+
+    assert(_storageSetIndex == externalDsLayouts.size());
+    Array<vk::DescriptorSetLayout> dsLayouts{scopeAlloc};
+    dsLayouts.resize(externalDsLayouts.size() + 1);
+    if (!externalDsLayouts.empty())
+        memcpy(
+            dsLayouts.data(), externalDsLayouts.data(),
+            externalDsLayouts.size() * sizeof(*externalDsLayouts.data()));
+    dsLayouts.back() = _storageSetLayout;
+
+    _pipelineLayout =
+        _device->logical().createPipelineLayout(vk::PipelineLayoutCreateInfo{
+            .setLayoutCount = asserted_cast<uint32_t>(dsLayouts.size()),
+            .pSetLayouts = dsLayouts.data(),
+            .pushConstantRangeCount = pcRange.size > 0 ? 1u : 0u,
+            .pPushConstantRanges = pcRange.size > 0 ? &pcRange : nullptr,
+        });
+
+    const vk::ComputePipelineCreateInfo createInfo{
+        .stage =
+            {
+                .stage = vk::ShaderStageFlagBits::eCompute,
+                .module = _shaderModule,
+                .pName = "main",
+            },
+        .layout = _pipelineLayout,
+    };
+
+    _pipeline =
+        createComputePipeline(_device->logical(), createInfo, "ComputePass");
+}

--- a/src/DepthOfField.cpp
+++ b/src/DepthOfField.cpp
@@ -1,8 +1,10 @@
 #include "DepthOfField.hpp"
 
+using namespace wheels;
+
 DepthOfField::DepthOfField(
-    wheels::ScopedScratch scopeAlloc, Device *device,
-    RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
+    ScopedScratch scopeAlloc, Device *device, RenderResources *resources,
+    DescriptorAllocator *staticDescriptorsAlloc,
     vk::DescriptorSetLayout cameraDsLayout)
 : _resources{resources}
 , _setupPass{scopeAlloc.child_scope(), device, resources, staticDescriptorsAlloc, cameraDsLayout}

--- a/src/DepthOfFieldCombine.cpp
+++ b/src/DepthOfFieldCombine.cpp
@@ -26,72 +26,31 @@ vk::Extent2D getRenderExtent(
     };
 }
 
+ComputePass::Shader shaderDefinitionCallback(Allocator &alloc)
+{
+    return ComputePass::Shader{
+        .relPath = "shader/dof/combine.comp",
+        .debugName = String{alloc, "DepthOfFieldCombineCS"},
+    };
+}
+
 } // namespace
 
 DepthOfFieldCombine::DepthOfFieldCombine(
     ScopedScratch scopeAlloc, Device *device, RenderResources *resources,
     DescriptorAllocator *staticDescriptorsAlloc)
-: _device{device}
-, _resources{resources}
+: _resources{resources}
+, _computePass{
+      WHEELS_MOV(scopeAlloc), device, staticDescriptorsAlloc,
+      shaderDefinitionCallback}
 {
-    assert(_device != nullptr);
     assert(_resources != nullptr);
-    assert(staticDescriptorsAlloc != nullptr);
-
-    printf("Creating DepthOfFieldCombine\n");
-    if (!compileShaders(scopeAlloc.child_scope()))
-        throw std::runtime_error(
-            "DepthOfFieldCombine shader compilation failed");
-
-    createDescriptorSets(scopeAlloc.child_scope(), staticDescriptorsAlloc);
-    createPipeline();
-}
-
-DepthOfFieldCombine::~DepthOfFieldCombine()
-{
-    if (_device != nullptr)
-    {
-        destroyPipelines();
-
-        _device->logical().destroy(_descriptorSetLayout);
-
-        _device->logical().destroy(_shaderModule);
-    }
 }
 
 void DepthOfFieldCombine::recompileShaders(wheels::ScopedScratch scopeAlloc)
 {
-    if (compileShaders(scopeAlloc.child_scope()))
-    {
-        destroyPipelines();
-        createPipeline();
-    }
-}
-
-bool DepthOfFieldCombine::compileShaders(ScopedScratch scopeAlloc)
-{
-    printf("Compiling DepthOfFieldCombine shaders\n");
-
-    Optional<Device::ShaderCompileResult> compResult =
-        _device->compileShaderModule(
-            scopeAlloc.child_scope(), Device::CompileShaderModuleArgs{
-                                          .relPath = "shader/dof/combine.comp",
-                                          .debugName = "DepthOfFieldCombineCS",
-                                      });
-
-    if (compResult.has_value())
-    {
-        _device->logical().destroy(_shaderModule);
-
-        ShaderReflection &reflection = compResult->reflection;
-
-        _shaderModule = compResult->module;
-        _shaderReflection = WHEELS_MOV(reflection);
-
-        return true;
-    }
-
-    return false;
+    _computePass.recompileShader(
+        WHEELS_MOV(scopeAlloc), shaderDefinitionCallback);
 }
 
 DepthOfFieldCombine::Output DepthOfFieldCombine::record(
@@ -108,132 +67,58 @@ DepthOfFieldCombine::Output DepthOfFieldCombine::record(
         ret.combinedIlluminationDoF = createIllumination(
             *_resources, renderExtent, "CombinedIllumnationDoF");
 
-        updateDescriptorSet(nextFrame, input, ret);
+        _computePass.updateDescriptorSet<5>(
+            nextFrame,
+            StaticArray{
+                DescriptorInfo{vk::DescriptorImageInfo{
+                    .imageView =
+                        _resources->images.resource(input.halfResFgBokehWeight)
+                            .view,
+                    .imageLayout = vk::ImageLayout::eGeneral,
+                }},
+                DescriptorInfo{vk::DescriptorImageInfo{
+                    .imageView =
+                        _resources->images.resource(input.halfResBgBokehWeight)
+                            .view,
+                    .imageLayout = vk::ImageLayout::eGeneral,
+                }},
+                DescriptorInfo{vk::DescriptorImageInfo{
+                    .imageView = _resources->images
+                                     .resource(input.halfResCircleOfConfusion)
+                                     .view,
+                    .imageLayout = vk::ImageLayout::eGeneral,
+                }},
+                DescriptorInfo{vk::DescriptorImageInfo{
+                    .imageView =
+                        _resources->images.resource(input.illumination).view,
+                    .imageLayout = vk::ImageLayout::eGeneral,
+                }},
+                DescriptorInfo{vk::DescriptorImageInfo{
+                    .imageView =
+                        _resources->images.resource(ret.combinedIlluminationDoF)
+                            .view,
+                    .imageLayout = vk::ImageLayout::eGeneral,
+                }},
+            });
 
-        recordBarriers(cb, input, ret);
+        transition<5>(
+            *_resources, cb,
+            {
+                {input.halfResFgBokehWeight, ImageState::ComputeShaderRead},
+                {input.halfResBgBokehWeight, ImageState::ComputeShaderRead},
+                {input.halfResCircleOfConfusion, ImageState::ComputeShaderRead},
+                {input.illumination, ImageState::ComputeShaderRead},
+                {ret.combinedIlluminationDoF, ImageState::ComputeShaderWrite},
+            });
 
         const auto _s = profiler->createCpuGpuScope(cb, "DepthOfFieldCombine");
 
-        cb.bindPipeline(vk::PipelineBindPoint::eCompute, _pipeline);
-
-        cb.bindDescriptorSets(
-            vk::PipelineBindPoint::eCompute, _pipelineLayout, 0, // firstSet
-            1, &_descriptorSets[nextFrame], 0, nullptr);
-
-        const auto groups =
-            (glm::uvec2{renderExtent.width, renderExtent.height} - 1u) / 16u +
-            1u;
-        cb.dispatch(groups.x, groups.y, 1);
+        const uvec3 groups = uvec3{
+            (uvec2{renderExtent.width, renderExtent.height} - 1u) / 16u + 1u,
+            1u};
+        const vk::DescriptorSet storageSet = _computePass.storageSet(nextFrame);
+        _computePass.record(cb, groups, Span{&storageSet, 1});
     }
 
     return ret;
-}
-
-void DepthOfFieldCombine::recordBarriers(
-    vk::CommandBuffer cb, const Input &input, const Output &output) const
-{
-    transition<5>(
-        *_resources, cb,
-        {
-            {input.halfResFgBokehWeight, ImageState::ComputeShaderRead},
-            {input.halfResBgBokehWeight, ImageState::ComputeShaderRead},
-            {input.halfResCircleOfConfusion, ImageState::ComputeShaderRead},
-            {input.illumination, ImageState::ComputeShaderRead},
-            {output.combinedIlluminationDoF, ImageState::ComputeShaderWrite},
-        });
-}
-
-void DepthOfFieldCombine::destroyPipelines()
-{
-    _device->logical().destroy(_pipeline);
-    _device->logical().destroy(_pipelineLayout);
-}
-
-void DepthOfFieldCombine::createDescriptorSets(
-    ScopedScratch scopeAlloc, DescriptorAllocator *staticDescriptorsAlloc)
-{
-    assert(_shaderReflection.has_value());
-    const Array<vk::DescriptorSetLayoutBinding> layoutBindings =
-        _shaderReflection->generateLayoutBindings(
-            scopeAlloc, 0, vk::ShaderStageFlagBits::eCompute);
-
-    _descriptorSetLayout = _device->logical().createDescriptorSetLayout(
-        vk::DescriptorSetLayoutCreateInfo{
-            .bindingCount = asserted_cast<uint32_t>(layoutBindings.size()),
-            .pBindings = layoutBindings.data(),
-        });
-
-    const StaticArray<vk::DescriptorSetLayout, MAX_FRAMES_IN_FLIGHT> layouts{
-        _descriptorSetLayout};
-    staticDescriptorsAlloc->allocate(layouts, _descriptorSets);
-}
-
-void DepthOfFieldCombine::updateDescriptorSet(
-    uint32_t nextFrame, const Input &input, const Output &output)
-{
-    // TODO:
-    // Don't update if resources are the same as before (for this DS index)?
-    // Have to compare against both extent and previous native handle?
-
-    const StaticArray bindingInfos = {
-        DescriptorInfo{vk::DescriptorImageInfo{
-            .imageView =
-                _resources->images.resource(input.halfResFgBokehWeight).view,
-            .imageLayout = vk::ImageLayout::eGeneral,
-        }},
-        DescriptorInfo{vk::DescriptorImageInfo{
-            .imageView =
-                _resources->images.resource(input.halfResBgBokehWeight).view,
-            .imageLayout = vk::ImageLayout::eGeneral,
-        }},
-
-        DescriptorInfo{vk::DescriptorImageInfo{
-            .imageView =
-                _resources->images.resource(input.halfResCircleOfConfusion)
-                    .view,
-            .imageLayout = vk::ImageLayout::eGeneral,
-        }},
-        DescriptorInfo{vk::DescriptorImageInfo{
-            .imageView = _resources->images.resource(input.illumination).view,
-            .imageLayout = vk::ImageLayout::eGeneral,
-        }},
-        DescriptorInfo{vk::DescriptorImageInfo{
-            .imageView =
-                _resources->images.resource(output.combinedIlluminationDoF)
-                    .view,
-            .imageLayout = vk::ImageLayout::eGeneral,
-        }},
-    };
-
-    const vk::DescriptorSet ds = _descriptorSets[nextFrame];
-
-    assert(_shaderReflection.has_value());
-    const StaticArray descriptorWrites =
-        _shaderReflection->generateDescriptorWrites(0, ds, bindingInfos);
-
-    _device->logical().updateDescriptorSets(
-        asserted_cast<uint32_t>(descriptorWrites.size()),
-        descriptorWrites.data(), 0, nullptr);
-}
-
-void DepthOfFieldCombine::createPipeline()
-{
-    _pipelineLayout =
-        _device->logical().createPipelineLayout(vk::PipelineLayoutCreateInfo{
-            .setLayoutCount = 1,
-            .pSetLayouts = &_descriptorSetLayout,
-        });
-
-    const vk::ComputePipelineCreateInfo createInfo{
-        .stage =
-            {
-                .stage = vk::ShaderStageFlagBits::eCompute,
-                .module = _shaderModule,
-                .pName = "main",
-            },
-        .layout = _pipelineLayout,
-    };
-
-    _pipeline = createComputePipeline(
-        _device->logical(), createInfo, "DepthOfFieldCombine");
 }

--- a/src/DepthOfFieldDilate.cpp
+++ b/src/DepthOfFieldDilate.cpp
@@ -25,72 +25,31 @@ vk::Extent2D getInputExtent(
     };
 }
 
+ComputePass::Shader shaderDefinitionCallback(Allocator &alloc)
+{
+    return ComputePass::Shader{
+        .relPath = "shader/dof/dilate.comp",
+        .debugName = String{alloc, "DepthOfFieldDilateCS"},
+    };
+}
+
 } // namespace
 
 DepthOfFieldDilate::DepthOfFieldDilate(
     ScopedScratch scopeAlloc, Device *device, RenderResources *resources,
     DescriptorAllocator *staticDescriptorsAlloc)
-: _device{device}
-, _resources{resources}
+: _resources{resources}
+, _computePass{
+      WHEELS_MOV(scopeAlloc), device, staticDescriptorsAlloc,
+      shaderDefinitionCallback}
 {
-    assert(_device != nullptr);
     assert(_resources != nullptr);
-    assert(staticDescriptorsAlloc != nullptr);
-
-    printf("Creating DepthOfFieldDilate\n");
-    if (!compileShaders(scopeAlloc.child_scope()))
-        throw std::runtime_error(
-            "DepthOfFieldDilate shader compilation failed");
-
-    createDescriptorSets(scopeAlloc.child_scope(), staticDescriptorsAlloc);
-    createPipeline();
-}
-
-DepthOfFieldDilate::~DepthOfFieldDilate()
-{
-    if (_device != nullptr)
-    {
-        destroyPipelines();
-
-        _device->logical().destroy(_descriptorSetLayout);
-
-        _device->logical().destroy(_compSM);
-    }
 }
 
 void DepthOfFieldDilate::recompileShaders(wheels::ScopedScratch scopeAlloc)
 {
-    if (compileShaders(scopeAlloc.child_scope()))
-    {
-        destroyPipelines();
-        createPipeline();
-    }
-}
-
-bool DepthOfFieldDilate::compileShaders(ScopedScratch scopeAlloc)
-{
-    printf("Compiling DepthOfFieldDilate shaders\n");
-
-    Optional<Device::ShaderCompileResult> compResult =
-        _device->compileShaderModule(
-            scopeAlloc.child_scope(), Device::CompileShaderModuleArgs{
-                                          .relPath = "shader/dof/dilate.comp",
-                                          .debugName = "DepthOfFieldDilateCS",
-                                      });
-
-    if (compResult.has_value())
-    {
-        _device->logical().destroy(_compSM);
-
-        ShaderReflection &reflection = compResult->reflection;
-
-        _compSM = compResult->module;
-        _shaderReflection = WHEELS_MOV(reflection);
-
-        return true;
-    }
-
-    return false;
+    _computePass.recompileShader(
+        WHEELS_MOV(scopeAlloc), shaderDefinitionCallback);
 }
 
 DepthOfFieldDilate::Output DepthOfFieldDilate::record(
@@ -114,113 +73,36 @@ DepthOfFieldDilate::Output DepthOfFieldDilate::record(
             },
             "dilatedTileMinMaxCoC");
 
-        updateDescriptorSet(nextFrame, tileMinMaxCoC, ret);
+        _computePass.updateDescriptorSet(
+            nextFrame,
+            StaticArray{
+                DescriptorInfo{vk::DescriptorImageInfo{
+                    .imageView =
+                        _resources->images.resource(tileMinMaxCoC).view,
+                    .imageLayout = vk::ImageLayout::eGeneral,
+                }},
+                DescriptorInfo{vk::DescriptorImageInfo{
+                    .imageView =
+                        _resources->images.resource(ret.dilatedTileMinMaxCoC)
+                            .view,
+                    .imageLayout = vk::ImageLayout::eGeneral,
+                }},
+            });
 
-        recordBarriers(cb, tileMinMaxCoC, ret);
+        transition<2>(
+            *_resources, cb,
+            {
+                {tileMinMaxCoC, ImageState::ComputeShaderRead},
+                {ret.dilatedTileMinMaxCoC, ImageState::ComputeShaderWrite},
+            });
 
         const auto _s = profiler->createCpuGpuScope(cb, "DepthOfFieldDilate");
 
-        cb.bindPipeline(vk::PipelineBindPoint::eCompute, _pipeline);
-
-        cb.bindDescriptorSets(
-            vk::PipelineBindPoint::eCompute, _pipelineLayout, 0, // firstSet
-            1, &_descriptorSets[nextFrame], 0, nullptr);
-
-        const auto groups =
-            (glm::uvec2{inputExtent.width, inputExtent.height} - 1u) / 16u + 1u;
-        cb.dispatch(groups.x, groups.y, 1);
+        const uvec3 groups = uvec3{
+            (uvec2{inputExtent.width, inputExtent.height} - 1u) / 16u + 1u, 1u};
+        const vk::DescriptorSet storageSet = _computePass.storageSet(nextFrame);
+        _computePass.record(cb, groups, Span{&storageSet, 1});
     }
 
     return ret;
-}
-
-void DepthOfFieldDilate::recordBarriers(
-    vk::CommandBuffer cb, ImageHandle tileMinMaxCoC, const Output &output) const
-{
-    transition<2>(
-        *_resources, cb,
-        {
-            {tileMinMaxCoC, ImageState::ComputeShaderRead},
-            {output.dilatedTileMinMaxCoC, ImageState::ComputeShaderWrite},
-        });
-}
-
-void DepthOfFieldDilate::destroyPipelines()
-{
-    _device->logical().destroy(_pipeline);
-    _device->logical().destroy(_pipelineLayout);
-}
-
-void DepthOfFieldDilate::createDescriptorSets(
-    ScopedScratch scopeAlloc, DescriptorAllocator *staticDescriptorsAlloc)
-{
-    assert(_shaderReflection.has_value());
-    const Array<vk::DescriptorSetLayoutBinding> layoutBindings =
-        _shaderReflection->generateLayoutBindings(
-            scopeAlloc, 0, vk::ShaderStageFlagBits::eCompute);
-
-    _descriptorSetLayout = _device->logical().createDescriptorSetLayout(
-        vk::DescriptorSetLayoutCreateInfo{
-            .bindingCount = asserted_cast<uint32_t>(layoutBindings.size()),
-            .pBindings = layoutBindings.data(),
-        });
-
-    const StaticArray<vk::DescriptorSetLayout, MAX_FRAMES_IN_FLIGHT> layouts{
-        _descriptorSetLayout};
-    staticDescriptorsAlloc->allocate(layouts, _descriptorSets);
-}
-
-void DepthOfFieldDilate::updateDescriptorSet(
-    uint32_t nextFrame, ImageHandle tileMinMaxCoC, const Output &output)
-{
-    // TODO:
-    // Don't update if resources are the same as before (for this DS index)?
-    // Have to compare against both extent and previous native handle?
-
-    const vk::DescriptorImageInfo inputInfo{
-        .imageView = _resources->images.resource(tileMinMaxCoC).view,
-        .imageLayout = vk::ImageLayout::eGeneral,
-    };
-    const vk::DescriptorImageInfo outputInfo{
-        .imageView =
-            _resources->images.resource(output.dilatedTileMinMaxCoC).view,
-        .imageLayout = vk::ImageLayout::eGeneral,
-    };
-
-    const vk::DescriptorSet ds = _descriptorSets[nextFrame];
-
-    assert(_shaderReflection.has_value());
-    const StaticArray descriptorWrites =
-        _shaderReflection->generateDescriptorWrites<2>(
-            0, ds,
-            {
-                DescriptorInfo{inputInfo},
-                DescriptorInfo{outputInfo},
-            });
-
-    _device->logical().updateDescriptorSets(
-        asserted_cast<uint32_t>(descriptorWrites.size()),
-        descriptorWrites.data(), 0, nullptr);
-}
-
-void DepthOfFieldDilate::createPipeline()
-{
-    _pipelineLayout =
-        _device->logical().createPipelineLayout(vk::PipelineLayoutCreateInfo{
-            .setLayoutCount = 1,
-            .pSetLayouts = &_descriptorSetLayout,
-        });
-
-    const vk::ComputePipelineCreateInfo createInfo{
-        .stage =
-            {
-                .stage = vk::ShaderStageFlagBits::eCompute,
-                .module = _compSM,
-                .pName = "main",
-            },
-        .layout = _pipelineLayout,
-    };
-
-    _pipeline = createComputePipeline(
-        _device->logical(), createInfo, "DepthOfFieldDilate");
 }

--- a/src/DepthOfFieldFlatten.cpp
+++ b/src/DepthOfFieldFlatten.cpp
@@ -25,72 +25,31 @@ vk::Extent2D getInputExtent(
     };
 }
 
+ComputePass::Shader shaderDefinitionCallback(Allocator &alloc)
+{
+    return ComputePass::Shader{
+        .relPath = "shader/dof/flatten.comp",
+        .debugName = String{alloc, "DepthOfFieldFlattenCS"},
+    };
+}
+
 } // namespace
 
 DepthOfFieldFlatten::DepthOfFieldFlatten(
     ScopedScratch scopeAlloc, Device *device, RenderResources *resources,
     DescriptorAllocator *staticDescriptorsAlloc)
-: _device{device}
-, _resources{resources}
+: _resources{resources}
+, _computePass{
+      WHEELS_MOV(scopeAlloc), device, staticDescriptorsAlloc,
+      shaderDefinitionCallback}
 {
-    assert(_device != nullptr);
     assert(_resources != nullptr);
-    assert(staticDescriptorsAlloc != nullptr);
-
-    printf("Creating DepthOfFieldFlatten\n");
-    if (!compileShaders(scopeAlloc.child_scope()))
-        throw std::runtime_error(
-            "DepthOfFieldFlatten shader compilation failed");
-
-    createDescriptorSets(scopeAlloc.child_scope(), staticDescriptorsAlloc);
-    createPipeline();
-}
-
-DepthOfFieldFlatten::~DepthOfFieldFlatten()
-{
-    if (_device != nullptr)
-    {
-        destroyPipelines();
-
-        _device->logical().destroy(_descriptorSetLayout);
-
-        _device->logical().destroy(_compSM);
-    }
 }
 
 void DepthOfFieldFlatten::recompileShaders(wheels::ScopedScratch scopeAlloc)
 {
-    if (compileShaders(scopeAlloc.child_scope()))
-    {
-        destroyPipelines();
-        createPipeline();
-    }
-}
-
-bool DepthOfFieldFlatten::compileShaders(ScopedScratch scopeAlloc)
-{
-    printf("Compiling DepthOfFieldFlatten shaders\n");
-
-    Optional<Device::ShaderCompileResult> compResult =
-        _device->compileShaderModule(
-            scopeAlloc.child_scope(), Device::CompileShaderModuleArgs{
-                                          .relPath = "shader/dof/flatten.comp",
-                                          .debugName = "DepthOfFieldFlattenCS",
-                                      });
-
-    if (compResult.has_value())
-    {
-        _device->logical().destroy(_compSM);
-
-        ShaderReflection &reflection = compResult->reflection;
-
-        _compSM = compResult->module;
-        _shaderReflection = WHEELS_MOV(reflection);
-
-        return true;
-    }
-
-    return false;
+    _computePass.recompileShader(
+        WHEELS_MOV(scopeAlloc), shaderDefinitionCallback);
 }
 
 DepthOfFieldFlatten::Output DepthOfFieldFlatten::record(
@@ -114,117 +73,39 @@ DepthOfFieldFlatten::Output DepthOfFieldFlatten::record(
             },
             "tileMinMaxCircleOfConfusion");
 
-        updateDescriptorSet(nextFrame, halfResCircleOfConfusion, ret);
+        _computePass.updateDescriptorSet(
+            nextFrame,
+            StaticArray{
+                DescriptorInfo{vk::DescriptorImageInfo{
+                    .imageView =
+                        _resources->images.resource(halfResCircleOfConfusion)
+                            .view,
+                    .imageLayout = vk::ImageLayout::eGeneral,
+                }},
+                DescriptorInfo{vk::DescriptorImageInfo{
+                    .imageView = _resources->images
+                                     .resource(ret.tileMinMaxCircleOfConfusion)
+                                     .view,
+                    .imageLayout = vk::ImageLayout::eGeneral,
+                }},
+            });
 
-        recordBarriers(cb, halfResCircleOfConfusion, ret);
+        transition<2>(
+            *_resources, cb,
+            {
+                {halfResCircleOfConfusion, ImageState::ComputeShaderRead},
+                {ret.tileMinMaxCircleOfConfusion,
+                 ImageState::ComputeShaderWrite},
+            });
 
         const auto _s = profiler->createCpuGpuScope(cb, "DepthOfFieldFlatten");
 
-        cb.bindPipeline(vk::PipelineBindPoint::eCompute, _pipeline);
-
-        cb.bindDescriptorSets(
-            vk::PipelineBindPoint::eCompute, _pipelineLayout, 0, // firstSet
-            1, &_descriptorSets[nextFrame], 0, nullptr);
-
-        const auto groups =
-            (glm::uvec2{inputExtent.width, inputExtent.height} - 1u) / 8u + 1u;
-        cb.dispatch(groups.x, groups.y, 1);
+        const uvec3 groups = uvec3{
+            (glm::uvec2{inputExtent.width, inputExtent.height} - 1u) / 8u + 1u,
+            1u};
+        const vk::DescriptorSet storageSet = _computePass.storageSet(nextFrame);
+        _computePass.record(cb, groups, Span{&storageSet, 1});
     }
 
     return ret;
-}
-
-void DepthOfFieldFlatten::recordBarriers(
-    vk::CommandBuffer cb, ImageHandle halfResCircleOfConfusion,
-    const Output &output) const
-{
-    transition<2>(
-        *_resources, cb,
-        {
-            {halfResCircleOfConfusion, ImageState::ComputeShaderRead},
-            {output.tileMinMaxCircleOfConfusion,
-             ImageState::ComputeShaderWrite},
-        });
-}
-
-void DepthOfFieldFlatten::destroyPipelines()
-{
-    _device->logical().destroy(_pipeline);
-    _device->logical().destroy(_pipelineLayout);
-}
-
-void DepthOfFieldFlatten::createDescriptorSets(
-    ScopedScratch scopeAlloc, DescriptorAllocator *staticDescriptorsAlloc)
-{
-    assert(_shaderReflection.has_value());
-    const Array<vk::DescriptorSetLayoutBinding> layoutBindings =
-        _shaderReflection->generateLayoutBindings(
-            scopeAlloc, 0, vk::ShaderStageFlagBits::eCompute);
-
-    _descriptorSetLayout = _device->logical().createDescriptorSetLayout(
-        vk::DescriptorSetLayoutCreateInfo{
-            .bindingCount = asserted_cast<uint32_t>(layoutBindings.size()),
-            .pBindings = layoutBindings.data(),
-        });
-
-    const StaticArray<vk::DescriptorSetLayout, MAX_FRAMES_IN_FLIGHT> layouts{
-        _descriptorSetLayout};
-    staticDescriptorsAlloc->allocate(layouts, _descriptorSets);
-}
-
-void DepthOfFieldFlatten::updateDescriptorSet(
-    uint32_t nextFrame, ImageHandle halfResCircleOfConfusion,
-    const Output &output)
-{
-    // TODO:
-    // Don't update if resources are the same as before (for this DS index)?
-    // Have to compare against both extent and previous native handle?
-
-    const vk::DescriptorImageInfo inputInfo{
-        .imageView = _resources->images.resource(halfResCircleOfConfusion).view,
-        .imageLayout = vk::ImageLayout::eGeneral,
-    };
-    const vk::DescriptorImageInfo outputInfo{
-        .imageView =
-            _resources->images.resource(output.tileMinMaxCircleOfConfusion)
-                .view,
-        .imageLayout = vk::ImageLayout::eGeneral,
-    };
-
-    const vk::DescriptorSet ds = _descriptorSets[nextFrame];
-
-    assert(_shaderReflection.has_value());
-    const StaticArray descriptorWrites =
-        _shaderReflection->generateDescriptorWrites<2>(
-            0, ds,
-            {
-                DescriptorInfo{inputInfo},
-                DescriptorInfo{outputInfo},
-            });
-
-    _device->logical().updateDescriptorSets(
-        asserted_cast<uint32_t>(descriptorWrites.size()),
-        descriptorWrites.data(), 0, nullptr);
-}
-
-void DepthOfFieldFlatten::createPipeline()
-{
-    _pipelineLayout =
-        _device->logical().createPipelineLayout(vk::PipelineLayoutCreateInfo{
-            .setLayoutCount = 1,
-            .pSetLayouts = &_descriptorSetLayout,
-        });
-
-    const vk::ComputePipelineCreateInfo createInfo{
-        .stage =
-            {
-                .stage = vk::ShaderStageFlagBits::eCompute,
-                .module = _compSM,
-                .pName = "main",
-            },
-        .layout = _pipelineLayout,
-    };
-
-    _pipeline = createComputePipeline(
-        _device->logical(), createInfo, "DepthOfFieldFlatten");
 }

--- a/src/DepthOfFieldGather.cpp
+++ b/src/DepthOfFieldGather.cpp
@@ -31,96 +31,46 @@ vk::Extent2D getRenderExtent(
     };
 }
 
+ComputePass::Shader backgroundDefinitionCallback(Allocator &alloc)
+{
+
+    String defines{alloc, 256};
+    appendDefineStr(defines, "GATHER_BACKGROUND");
+    return ComputePass::Shader{
+        .relPath = "shader/dof/gather.comp",
+        .debugName = String{alloc, "DepthOfFieldGatherBgCS"},
+        .defines = WHEELS_MOV(defines),
+    };
+}
+
+ComputePass::Shader foregroundDefinitionCallback(Allocator &alloc)
+{
+    return ComputePass::Shader{
+        .relPath = "shader/dof/gather.comp",
+        .debugName = String{alloc, "DepthOfFieldGatherFgCS"},
+    };
+}
+
 } // namespace
 
 DepthOfFieldGather::DepthOfFieldGather(
     ScopedScratch scopeAlloc, Device *device, RenderResources *resources,
     DescriptorAllocator *staticDescriptorsAlloc)
-: _device{device}
-, _resources{resources}
+: _resources{resources}
+, _backgroundPass{scopeAlloc.child_scope(), device, staticDescriptorsAlloc, backgroundDefinitionCallback}
+, _foregroundPass{
+      scopeAlloc.child_scope(), device, staticDescriptorsAlloc,
+      foregroundDefinitionCallback}
 {
-    assert(_device != nullptr);
     assert(_resources != nullptr);
-    assert(staticDescriptorsAlloc != nullptr);
-
-    printf("Creating DepthOfFieldGather\n");
-    if (!compileShaders(scopeAlloc.child_scope()))
-        throw std::runtime_error(
-            "DepthOfFieldGather shader compilation failed");
-
-    createDescriptorSets(scopeAlloc.child_scope(), staticDescriptorsAlloc);
-    createPipeline();
-}
-
-DepthOfFieldGather::~DepthOfFieldGather()
-{
-    if (_device != nullptr)
-    {
-        destroyPipelines();
-
-        _device->logical().destroy(_descriptorSetLayout);
-
-        for (const vk::ShaderModule sm : _shaderModules)
-            _device->logical().destroy(sm);
-    }
 }
 
 void DepthOfFieldGather::recompileShaders(wheels::ScopedScratch scopeAlloc)
 {
-    if (compileShaders(scopeAlloc.child_scope()))
-    {
-        destroyPipelines();
-        createPipeline();
-    }
-}
-
-bool DepthOfFieldGather::compileShaders(ScopedScratch scopeAlloc)
-{
-    printf("Compiling DepthOfFieldGather shaders\n");
-
-    auto compileShader = [&](GatherType gatherType)
-    {
-        assert(gatherType < GatherType_Count);
-
-        String defines{scopeAlloc, 256};
-        if (gatherType == GatherType_Background)
-            appendDefineStr(defines, "GATHER_BACKGROUND");
-
-        Optional<Device::ShaderCompileResult> compResult =
-            _device->compileShaderModule(
-                scopeAlloc.child_scope(),
-                Device::CompileShaderModuleArgs{
-                    .relPath = "shader/dof/gather.comp",
-                    .debugName = gatherType == GatherType_Background
-                                     ? "DepthOfFieldGatherBgCS"
-                                     : "DepthOfFieldGatherFgCS",
-                    .defines = defines,
-                });
-
-        if (compResult.has_value())
-        {
-            _device->logical().destroy(_shaderModules[gatherType]);
-
-            ShaderReflection &reflection = compResult->reflection;
-            assert(sizeof(PCBlock) == reflection.pushConstantsBytesize());
-
-            _shaderModules[gatherType] = compResult->module;
-
-            if (_shaderReflections.size() > gatherType)
-                _shaderReflections[gatherType] = WHEELS_MOV(reflection);
-            else
-                _shaderReflections.push_back(WHEELS_MOV(reflection));
-
-            return true;
-        }
-        return false;
-    };
-
-    for (uint32_t i = 0; i < GatherType_Count; ++i)
-        if (!compileShader(static_cast<GatherType>(i)))
-            return false;
-
-    return true;
+    _backgroundPass.recompileShader(
+        scopeAlloc.child_scope(), backgroundDefinitionCallback);
+    _foregroundPass.recompileShader(
+        scopeAlloc.child_scope(), foregroundDefinitionCallback);
 }
 
 DepthOfFieldGather::Output DepthOfFieldGather::record(
@@ -129,6 +79,10 @@ DepthOfFieldGather::Output DepthOfFieldGather::record(
 {
     assert(profiler != nullptr);
     assert(gatherType < GatherType_Count);
+
+    ComputePass *computePass = gatherType == GatherType_Foreground
+                                   ? &_foregroundPass
+                                   : &_backgroundPass;
 
     if (gatherType == GatherType_Foreground)
         _frameIndex = (_frameIndex + 1) % 128;
@@ -148,163 +102,58 @@ DepthOfFieldGather::Output DepthOfFieldGather::record(
             },
             gatherType == GatherType_Background ? "halfResBgBokehColorWeight"
                                                 : "halfResFgBokehColorWeight");
-        vk::DescriptorSet const descriptorSet =
-            _descriptorSets[GatherType_Count * nextFrame + gatherType];
 
-        updateDescriptorSet(descriptorSet, gatherType, input, ret);
+        computePass->updateDescriptorSet(
+            nextFrame,
+            StaticArray{
+                DescriptorInfo{vk::DescriptorImageInfo{
+                    .imageView =
+                        _resources->images.resource(input.halfResIllumination)
+                            .view,
+                    .imageLayout = vk::ImageLayout::eGeneral,
+                }},
+                DescriptorInfo{vk::DescriptorImageInfo{
+                    .imageView =
+                        _resources->images.resource(input.halfResCoC).view,
+                    .imageLayout = vk::ImageLayout::eGeneral,
+                }},
+                DescriptorInfo{vk::DescriptorImageInfo{
+                    .imageView =
+                        _resources->images.resource(input.dilatedTileMinMaxCoC)
+                            .view,
+                    .imageLayout = vk::ImageLayout::eGeneral,
+                }},
+                DescriptorInfo{vk::DescriptorImageInfo{
+                    .imageView =
+                        _resources->images.resource(ret.halfResBokehColorWeight)
+                            .view,
+                    .imageLayout = vk::ImageLayout::eGeneral,
+                }},
+            });
 
-        recordBarriers(cb, input, ret);
+        transition<4>(
+            *_resources, cb,
+            {
+                {input.halfResIllumination, ImageState::ComputeShaderRead},
+                {input.halfResCoC, ImageState::ComputeShaderRead},
+                {input.dilatedTileMinMaxCoC, ImageState::ComputeShaderRead},
+                {ret.halfResBokehColorWeight, ImageState::ComputeShaderWrite},
+            });
 
         const auto _s = profiler->createCpuGpuScope(
             cb, gatherType == GatherType_Background ? "DepthOfFieldGatherBg"
                                                     : "DepthOfFieldGatherFg");
 
-        cb.bindPipeline(
-            vk::PipelineBindPoint::eCompute, _pipelines[gatherType]);
-
-        cb.bindDescriptorSets(
-            vk::PipelineBindPoint::eCompute, _pipelineLayout, 0, // firstSet
-            1, &descriptorSet, 0, nullptr);
-
         const PCBlock pcBlock{
             .frameIndex = _frameIndex,
         };
-        cb.pushConstants(
-            _pipelineLayout, vk::ShaderStageFlagBits::eCompute, 0,
-            sizeof(PCBlock), &pcBlock);
-
-        const auto groups =
+        const uvec3 groups = uvec3{
             (glm::uvec2{renderExtent.width, renderExtent.height} - 1u) / 16u +
-            1u;
-        cb.dispatch(groups.x, groups.y, 1);
+                1u,
+            1u};
+        const vk::DescriptorSet storageSet = computePass->storageSet(nextFrame);
+        computePass->record(cb, pcBlock, groups, Span{&storageSet, 1});
     }
 
     return ret;
-}
-
-void DepthOfFieldGather::recordBarriers(
-    vk::CommandBuffer cb, const Input &input, const Output &output) const
-{
-    transition<4>(
-        *_resources, cb,
-        {
-            {input.halfResIllumination, ImageState::ComputeShaderRead},
-            {input.halfResCoC, ImageState::ComputeShaderRead},
-            {input.dilatedTileMinMaxCoC, ImageState::ComputeShaderRead},
-            {output.halfResBokehColorWeight, ImageState::ComputeShaderWrite},
-        });
-}
-
-void DepthOfFieldGather::destroyPipelines()
-{
-    for (const vk::Pipeline p : _pipelines)
-        _device->logical().destroy(p);
-    _pipelines.clear();
-    _device->logical().destroy(_pipelineLayout);
-}
-
-void DepthOfFieldGather::createDescriptorSets(
-    ScopedScratch scopeAlloc, DescriptorAllocator *staticDescriptorsAlloc)
-{
-    assert(_shaderReflections.size() == 2);
-    const Array<vk::DescriptorSetLayoutBinding> layoutBindings =
-        _shaderReflections[0].generateLayoutBindings(
-            scopeAlloc, 0, vk::ShaderStageFlagBits::eCompute);
-
-    _descriptorSetLayout = _device->logical().createDescriptorSetLayout(
-        vk::DescriptorSetLayoutCreateInfo{
-            .bindingCount = asserted_cast<uint32_t>(layoutBindings.size()),
-            .pBindings = layoutBindings.data(),
-        });
-
-#ifndef NDEBUG
-    // Make sure we really can use the same layout for all sets
-    // This is maybe overkill
-    for (uint32_t gatherType = 0; gatherType < GatherType_Count; ++gatherType)
-    {
-        const Array<vk::DescriptorSetLayoutBinding> lb =
-            _shaderReflections[gatherType].generateLayoutBindings(
-                scopeAlloc, 0, vk::ShaderStageFlagBits::eCompute);
-        assert(lb.size() == layoutBindings.size());
-        for (size_t i = 0; i < lb.size(); ++i)
-            assert(lb[i] == layoutBindings[i]);
-    }
-#endif // NDEBUG
-
-    const StaticArray<vk::DescriptorSetLayout, DescriptorSets::capacity()>
-        layouts{_descriptorSetLayout};
-    staticDescriptorsAlloc->allocate(layouts, _descriptorSets);
-}
-
-void DepthOfFieldGather::updateDescriptorSet(
-    vk::DescriptorSet descriptorSet, GatherType gatherType, const Input &input,
-    const Output &output)
-{
-    // TODO:
-    // Don't update if resources are the same as before (for this DS index)?
-    // Have to compare against both extent and previous native handle?
-
-    const StaticArray bindingInfos = {
-        DescriptorInfo{vk::DescriptorImageInfo{
-            .imageView =
-                _resources->images.resource(input.halfResIllumination).view,
-            .imageLayout = vk::ImageLayout::eGeneral,
-        }},
-        DescriptorInfo{vk::DescriptorImageInfo{
-            .imageView = _resources->images.resource(input.halfResCoC).view,
-            .imageLayout = vk::ImageLayout::eGeneral,
-        }},
-        DescriptorInfo{vk::DescriptorImageInfo{
-            .imageView =
-                _resources->images.resource(input.dilatedTileMinMaxCoC).view,
-            .imageLayout = vk::ImageLayout::eGeneral,
-        }},
-        DescriptorInfo{vk::DescriptorImageInfo{
-            .imageView =
-                _resources->images.resource(output.halfResBokehColorWeight)
-                    .view,
-            .imageLayout = vk::ImageLayout::eGeneral,
-        }},
-    };
-
-    assert(_shaderReflections.size() > gatherType);
-    const StaticArray descriptorWrites =
-        _shaderReflections[gatherType].generateDescriptorWrites(
-            0, descriptorSet, bindingInfos);
-
-    _device->logical().updateDescriptorSets(
-        asserted_cast<uint32_t>(descriptorWrites.size()),
-        descriptorWrites.data(), 0, nullptr);
-}
-
-void DepthOfFieldGather::createPipeline()
-{
-    const vk::PushConstantRange pcRange{
-        .stageFlags = vk::ShaderStageFlagBits::eCompute,
-        .offset = 0,
-        .size = sizeof(PCBlock),
-    };
-    _pipelineLayout =
-        _device->logical().createPipelineLayout(vk::PipelineLayoutCreateInfo{
-            .setLayoutCount = 1,
-            .pSetLayouts = &_descriptorSetLayout,
-            .pushConstantRangeCount = 1,
-            .pPushConstantRanges = &pcRange,
-        });
-
-    for (uint32_t i = 0; i < GatherType_Count; ++i)
-    {
-        const vk::ComputePipelineCreateInfo createInfo{
-            .stage =
-                {
-                    .stage = vk::ShaderStageFlagBits::eCompute,
-                    .module = _shaderModules[i],
-                    .pName = "main",
-                },
-            .layout = _pipelineLayout,
-        };
-
-        _pipelines.push_back(createComputePipeline(
-            _device->logical(), createInfo, "DepthOfFieldGather"));
-    }
 }


### PR DESCRIPTION
This gets rid of two thirds of the code in the current compute passes.  The new interface seems ergonomic and transparent for the current compute needs but I'm sure it's nowhere near 'final'.