### PR TITLE
Tag dynamic storage buffers in shader + cleanup

### DIFF
--- a/res/shader/scene/camera.glsl
+++ b/res/shader/scene/camera.glsl
@@ -1,7 +1,7 @@
 #ifndef SCENE_CAMERA_GLSL
 #define SCENE_CAMERA_GLSL
 
-layout(std430, set = CAMERA_SET, binding = 0) buffer Camera
+layout(std430, set = CAMERA_SET, binding = 0) buffer CameraDSB
 {
     mat4 worldToCamera;
     mat4 cameraToWorld;

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -387,7 +387,7 @@ void App::handleMouseGestures()
             const auto flipUp =
                 dot(right, cross(newFromTarget, params.up)) < 0.0;
 
-            _cam->offset = CameraOffset{
+            _cam->gestureOffset = CameraOffset{
                 .eye = newFromTarget - fromTarget,
                 .flipUp = flipUp,
             };
@@ -413,14 +413,14 @@ void App::handleMouseGestures()
 
             const auto offset = right * (drag.x) + cam_up * (drag.y);
 
-            _cam->offset = CameraOffset{
+            _cam->gestureOffset = CameraOffset{
                 .eye = offset,
                 .target = offset,
             };
         }
         else if (gesture->type == MouseGestureType::TrackZoom)
         {
-            if (!_cam->offset.has_value())
+            if (!_cam->gestureOffset.has_value())
             {
                 const auto &params = _cam->parameters();
 
@@ -441,7 +441,7 @@ void App::handleMouseGestures()
                         vec3(compMax(
                             0.01f * max(offsetParams.eye, params.target))))))
                 {
-                    _cam->offset = offset;
+                    _cam->gestureOffset = offset;
                 }
             }
         }
@@ -450,9 +450,9 @@ void App::handleMouseGestures()
     }
     else
     {
-        if (_cam->offset.has_value())
+        if (_cam->gestureOffset.has_value())
         {
-            _cam->applyOffset();
+            _cam->applyGestureOffset();
         }
     }
 }
@@ -503,7 +503,7 @@ void App::handleKeyboardInput(float deltaS)
     if (length(speed) > 0.f)
     {
         const CameraParameters &params = _cam->parameters();
-        const Optional<CameraOffset> &offset = _cam->offset;
+        const Optional<CameraOffset> &offset = _cam->gestureOffset;
 
         const vec3 eye =
             offset.has_value() ? params.eye + offset->eye : params.eye;

--- a/src/gfx/Device.cpp
+++ b/src/gfx/Device.cpp
@@ -554,7 +554,7 @@ wheels::Optional<Device::ShaderCompileResult> Device::compileShaderModule(
         result.begin(), asserted_cast<size_t>(result.end() - result.begin())};
 
     ShaderReflection reflection{
-        scopeAlloc.child_scope(), _generalAlloc, spvWords, info.dynamicBuffers};
+        scopeAlloc.child_scope(), _generalAlloc, spvWords};
 
     const auto sm = _logical.createShaderModule(vk::ShaderModuleCreateInfo{
         .codeSize = spvWords.size() * sizeof(uint32_t),
@@ -632,7 +632,7 @@ void main()
         result.begin(), asserted_cast<size_t>(result.end() - result.begin())};
 
     ShaderReflection reflection{
-        scopeAlloc.child_scope(), _generalAlloc, spvWords, info.dynamicBuffers};
+        scopeAlloc.child_scope(), _generalAlloc, spvWords};
 
     return WHEELS_MOV(reflection);
 }

--- a/src/gfx/Device.hpp
+++ b/src/gfx/Device.hpp
@@ -117,7 +117,6 @@ class Device
         const std::filesystem::path &relPath;
         const char *debugName{nullptr};
         wheels::StrSpan defines{""};
-        wheels::Span<const wheels::String> dynamicBuffers{};
     };
     struct ShaderCompileResult
     {

--- a/src/gfx/ShaderReflection.hpp
+++ b/src/gfx/ShaderReflection.hpp
@@ -33,8 +33,7 @@ class ShaderReflection
     ShaderReflection(wheels::Allocator &alloc);
     ShaderReflection(
         wheels::ScopedScratch scopeAlloc, wheels::Allocator &alloc,
-        wheels::Span<const uint32_t> spvWords,
-        wheels::Span<const wheels::String> dynamicBuffers = {});
+        wheels::Span<const uint32_t> spvWords);
     ~ShaderReflection() = default;
 
     ShaderReflection(const ShaderReflection &) = delete;

--- a/src/render/RenderResourceCollection.hpp
+++ b/src/render/RenderResourceCollection.hpp
@@ -157,7 +157,9 @@ void RenderResourceCollection<
         if (_preserved[i])
             _preserved[i] = false;
         else
-            assert(!resourceInUse(i) && "Resource leaked");
+            assert(
+                !resourceInUse(asserted_cast<uint32_t>(i)) &&
+                "Resource leaked");
         (void)aliasedDebugName;
     }
 #endif // NDEBUG

--- a/src/scene/Camera.cpp
+++ b/src/scene/Camera.cpp
@@ -138,7 +138,7 @@ bool Camera::drawUI()
 
 void Camera::updateBuffer(const uvec2 &resolution)
 {
-    if (offset.has_value())
+    if (gestureOffset.has_value())
     {
         updateWorldToCamera();
     }
@@ -150,8 +150,9 @@ void Camera::updateBuffer(const uvec2 &resolution)
         .clipToWorld = _clipToWorld,
         .eye =
             vec4{
-                offset.has_value() ? _parameters.apply(*offset).eye
-                                   : _parameters.eye,
+                gestureOffset.has_value()
+                    ? _parameters.apply(*gestureOffset).eye
+                    : _parameters.eye,
                 1.f},
         .resolution = resolution,
         .near = _parameters.zN,
@@ -186,12 +187,12 @@ void Camera::clearChangedThisFrame() { _changedThisFrame = false; }
 
 bool Camera::changedThisFrame() const { return _changedThisFrame; }
 
-void Camera::applyOffset()
+void Camera::applyGestureOffset()
 {
-    if (offset.has_value())
+    if (gestureOffset.has_value())
     {
-        _parameters = _parameters.apply(*offset);
-        offset.reset();
+        _parameters = _parameters.apply(*gestureOffset);
+        gestureOffset.reset();
     }
 
     updateWorldToCamera();
@@ -260,8 +261,9 @@ void Camera::createDescriptorSet(
 
 void Camera::updateWorldToCamera()
 {
-    const auto parameters =
-        offset.has_value() ? _parameters.apply(*offset) : _parameters;
+    const auto parameters = gestureOffset.has_value()
+                                ? _parameters.apply(*gestureOffset)
+                                : _parameters;
     auto const &[eye, target, up, _fov, _ar, _zN, _zF] = parameters;
 
     const vec3 fwd = normalize(target - eye);

--- a/src/scene/Camera.cpp
+++ b/src/scene/Camera.cpp
@@ -209,13 +209,11 @@ void Camera::createBindingsReflection(ScopedScratch scopeAlloc)
     String defines{scopeAlloc, 64};
     appendDefineStr(defines, "CAMERA_SET", sBindingSetIndex);
 
-    const String dynamicBuffer{scopeAlloc, sCameraBindingName};
     Optional<ShaderReflection> compResult = _device->reflectShader(
         scopeAlloc.child_scope(),
         Device::CompileShaderModuleArgs{
             .relPath = "shader/scene/camera.glsl",
             .defines = defines,
-            .dynamicBuffers = Span{&dynamicBuffer, 1},
         },
         true);
     if (!compResult.has_value())

--- a/src/scene/Camera.hpp
+++ b/src/scene/Camera.hpp
@@ -102,9 +102,9 @@ class Camera
     [[nodiscard]] bool changedThisFrame() const;
 
     // This offset, if any, is added to internal transformation
-    wheels::Optional<CameraOffset> offset;
+    wheels::Optional<CameraOffset> gestureOffset;
     // Permanently applies 'offset' and empties it
-    void applyOffset();
+    void applyGestureOffset();
     // Applies an offset without touching the held one
     void applyOffset(const CameraOffset &offset);
 


### PR DESCRIPTION
Listing DSBs in c++ feels excessive in hindsight as they can be tagged in shader without affecting shader access code. Let's do that for now.