### PR TITLE
Simplify skybox binds

### DIFF
--- a/res/shader/skybox.frag
+++ b/res/shader/skybox.frag
@@ -6,7 +6,7 @@ layout(location = 0) in vec3 fragTexCoord;
 
 layout(location = 0) out vec4 outColor;
 
-layout(binding = 1) uniform samplerCube skybox;
+layout(binding = 0) uniform samplerCube skybox;
 
 float sRGBtoLinear(float x)
 {

--- a/res/shader/skybox.vert
+++ b/res/shader/skybox.vert
@@ -2,12 +2,12 @@
 
 #extension GL_ARB_separate_shader_objects : enable
 
-layout(binding = 0) uniform Camera
+layout(push_constant) uniform SkyboxPC
 {
     mat4 worldToClip; // This shouldn't have camera translation to keep skybox
                       // stationary
 }
-camera;
+skyboxPC;
 
 layout(location = 0) in vec3 vertPosition;
 
@@ -16,7 +16,7 @@ layout(location = 0) out vec3 fragTexCoord;
 void main()
 {
     fragTexCoord = vertPosition;
-    vec4 pos = camera.worldToClip * vec4(vertPosition, 1);
+    vec4 pos = skyboxPC.worldToClip * vec4(vertPosition, 1);
     // Put the skybox at depth 0 in NDC since we use reverse-z
     gl_Position = vec4(pos.xy, 0, pos.w);
 }

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -548,7 +548,7 @@ void App::drawFrame(ScopedScratch scopeAlloc, uint32_t scopeHighWatermark)
     _cam->updateBuffer(
         uvec2{renderArea.extent.width, renderArea.extent.height});
 
-    _world->updateBuffers(*_cam, nextFrame, scopeAlloc.child_scope());
+    _world->updateBuffers(scopeAlloc.child_scope());
 
     updateDebugLines(_world->currentScene(), nextFrame);
 
@@ -970,12 +970,12 @@ void App::render(
             lightClusters, indices.nextFrame, _profiler.get());
 
         _skyboxRenderer->record(
-            cb, *_world,
+            cb, *_world, *_cam,
             SkyboxRenderer::RecordInOut{
                 .illumination = illumination,
                 .depth = depth,
             },
-            indices.nextFrame, _profiler.get());
+            _profiler.get());
 
         _debugRenderer->record(
             cb, *_cam,

--- a/src/gfx/ShaderReflection.cpp
+++ b/src/gfx/ShaderReflection.cpp
@@ -468,7 +468,7 @@ uint32_t memberBytesize(
                 const SpvResult &lastMemberResult = results[lastMemberId];
 
                 const uint32_t lastMemberBytesize = memberBytesize(
-                    lastMemberResult.type, MemberDecorations{}, results);
+                    lastMemberResult.type, lastMemberDecorations, results);
 
                 assert(lastMemberDecorations.offset != sUninitialized);
                 const uint32_t bytesize =

--- a/src/render/RTRenderer.cpp
+++ b/src/render/RTRenderer.cpp
@@ -233,7 +233,7 @@ RTRenderer::Output RTRenderer::record(
             world._materialDatasDSs[nextFrame];
         descriptorSets[MaterialTexturesBindingSet] = world._materialTexturesDS;
         descriptorSets[GeometryBindingSet] = world._geometryDS;
-        descriptorSets[SkyboxBindingSet] = world._skyboxOnlyDS;
+        descriptorSets[SkyboxBindingSet] = world._skyboxDS;
         descriptorSets[ModelInstanceTrfnsBindingSet] =
             scene.modelInstancesDescriptorSet;
         descriptorSets[LightsBindingSet] = world._lightsDescriptorSet;
@@ -596,7 +596,7 @@ void RTRenderer::createPipeline(
     setLayouts[MaterialDatasBindingSet] = worldDSLayouts.materialDatas;
     setLayouts[MaterialTexturesBindingSet] = worldDSLayouts.materialTextures;
     setLayouts[GeometryBindingSet] = worldDSLayouts.geometry;
-    setLayouts[SkyboxBindingSet] = worldDSLayouts.skyboxOnly;
+    setLayouts[SkyboxBindingSet] = worldDSLayouts.skybox;
     setLayouts[ModelInstanceTrfnsBindingSet] = worldDSLayouts.modelInstances;
     setLayouts[LightsBindingSet] = worldDSLayouts.lights;
 

--- a/src/render/SkyboxRenderer.hpp
+++ b/src/render/SkyboxRenderer.hpp
@@ -34,9 +34,8 @@ class SkyboxRenderer
         ImageHandle depth;
     };
     void record(
-        vk::CommandBuffer cb, const World &world,
-        const RecordInOut &inOutTargets, uint32_t nextFrame,
-        Profiler *profiler) const;
+        vk::CommandBuffer cb, const World &world, const Camera &camera,
+        const RecordInOut &inOutTargets, Profiler *profiler) const;
 
   private:
     [[nodiscard]] bool compileShaders(wheels::ScopedScratch scopeAlloc);

--- a/src/scene/World.hpp
+++ b/src/scene/World.hpp
@@ -42,7 +42,6 @@ class World
         vk::DescriptorSetLayout rayTracing;
         vk::DescriptorSetLayout lights;
         vk::DescriptorSetLayout skybox;
-        vk::DescriptorSetLayout skyboxOnly;
     };
     World(
         wheels::Allocator &generalAlloc, wheels::ScopedScratch scopeAlloc,
@@ -65,9 +64,7 @@ class World
     void drawDeferredLoadingUi() const;
 
     [[nodiscard]] const Scene &currentScene() const;
-    void updateBuffers(
-        const Camera &cam, uint32_t nextFrame,
-        wheels::ScopedScratch scopeAlloc);
+    void updateBuffers(wheels::ScopedScratch scopeAlloc);
     void drawSkybox(const vk::CommandBuffer &buffer) const;
 
     wheels::Allocator &_generalAlloc;
@@ -114,9 +111,7 @@ class World
     uint32_t _pointLightByteOffset{0};
     uint32_t _spotLightByteOffset{0};
 
-    wheels::StaticArray<Buffer, MAX_FRAMES_IN_FLIGHT> _skyboxUniformBuffers;
-    wheels::StaticArray<vk::DescriptorSet, MAX_FRAMES_IN_FLIGHT> _skyboxDSs;
-    vk::DescriptorSet _skyboxOnlyDS;
+    vk::DescriptorSet _skyboxDS;
 
     struct DeferredLoadingContext
     {


### PR DESCRIPTION
A UBO for just one matrix is overkill and requires multiple descriptor sets.