### PR TITLE
shaders: Make it clear that evalBRDF also applies NoL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Get dependencies
-        run: sudo apt install xorg-dev
+        run: sudo apt update && sudo apt install xorg-dev
 
       - name: Prepare Vulkan SDK
         uses: humbletim/setup-vulkan-sdk@v1.2.0
@@ -94,7 +94,7 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Get dependencies
-        run: sudo apt install xorg-dev clang-15
+        run: sudo apt update && sudo apt install xorg-dev clang-15
 
       - name: Prepare Vulkan SDK
         uses: humbletim/setup-vulkan-sdk@v1.2.0

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Get clang-format 15
-        run: sudo apt install clang-format-15
+        run: sudo apt update && sudo apt install clang-format-15
 
       - name: Run clang-format
         run: >

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -22,7 +22,7 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Get dependencies
-        run: sudo apt install xorg-dev clang-tidy-15
+        run: sudo apt update && sudo apt install xorg-dev clang-tidy-15
 
       - name: Prepare Vulkan SDK
         uses: humbletim/setup-vulkan-sdk@v1.2.0
@@ -55,7 +55,7 @@ jobs:
         uses: lukka/get-cmake@latest
 
       - name: Get dependencies
-        run: sudo apt install xorg-dev clang-tidy-15
+        run: sudo apt update && sudo apt install xorg-dev clang-tidy-15
 
       - name: Prepare Vulkan SDK
         uses: humbletim/setup-vulkan-sdk@v1.2.0

--- a/res/shader/brdf.glsl
+++ b/res/shader/brdf.glsl
@@ -50,7 +50,7 @@ vec3 cookTorranceBRDF(
 }
 
 // Evaluate combined diffuse and specular BRDF
-vec3 evalBRDF(vec3 l, VisibleSurface surface)
+vec3 evalBRDFTimesNoL(vec3 l, VisibleSurface surface)
 {
     // Common dot products
     vec3 h = normalize(surface.invViewRayWS + l);

--- a/res/shader/rt/scene.rgen
+++ b/res/shader/rt/scene.rgen
@@ -177,7 +177,7 @@ void main()
                 addBounce(
                     color,
                     200 * vec3(255, 236, 224) / 255. * throughput *
-                        evalBRDF(l, surface) *
+                        evalBRDFTimesNoL(l, surface) *
                         shadow(surface.positionWS, l, 0.1, 100),
                     bounce);
             }
@@ -190,7 +190,7 @@ void main()
         float pdf;
         cosineSampleHemisphere(surface.normalWS, rnd2d01(), rd, pdf);
 
-        throughput *= evalBRDF(rd, surface) / pdf;
+        throughput *= evalBRDFTimesNoL(rd, surface) / pdf;
 
         ray.o = offsetRay(surface);
         ray.d = rd;

--- a/res/shader/scene/lighting.glsl
+++ b/res/shader/scene/lighting.glsl
@@ -8,7 +8,7 @@
 vec3 evalDirectionalLight(VisibleSurface surface)
 {
     vec3 l = -normalize(directionalLight.direction.xyz);
-    return directionalLight.irradiance.xyz * evalBRDF(l, surface);
+    return directionalLight.irradiance.xyz * evalBRDFTimesNoL(l, surface);
 }
 
 vec3 evalPointLights(VisibleSurface surface, LightClusterInfo lightInfo)
@@ -33,7 +33,7 @@ vec3 evalPointLights(VisibleSurface surface, LightClusterInfo lightInfo)
         float dPerR4 = dPerR2 * dPerR2;
         float attenuation = max(min(1.0 - dPerR4, 1), 0) / d2;
 
-        color += radiance * attenuation * evalBRDF(l, surface);
+        color += radiance * attenuation * evalBRDFTimesNoL(l, surface);
     }
     return color;
 }
@@ -60,7 +60,7 @@ vec3 evalSpotLights(VisibleSurface surface, LightClusterInfo lightInfo)
         angularAttenuation *= angularAttenuation;
 
         color += angularAttenuation * light.radianceAndAngleScale.xyz *
-                 evalBRDF(l, surface) / d2;
+                 evalBRDFTimesNoL(l, surface) / d2;
     }
     return color;
 }


### PR DESCRIPTION
All current usages would do it anyway so this seems cleaner than separating the multiply out.