### PR TITLE
Remove the need for formats in image2d load/store

### DIFF
--- a/res/shader/deferred_shading.comp
+++ b/res/shader/deferred_shading.comp
@@ -1,6 +1,7 @@
 #pragma shader_stage(compute)
 
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_image_load_formatted : require
 
 #include "brdf.glsl"
 #include "debug.glsl"
@@ -11,12 +12,12 @@
 #include "scene/skybox.glsl"
 
 layout(local_size_x = 16, local_size_y = 16) in;
-layout(set = STORAGE_SET, binding = 0, rgba8) uniform readonly image2D
+layout(set = STORAGE_SET, binding = 0) uniform readonly image2D
     inAlbedoRoughness;
-layout(set = STORAGE_SET, binding = 1, rgba16) uniform readonly image2D
+layout(set = STORAGE_SET, binding = 1) uniform readonly image2D
     inNormalMetallic;
 layout(set = STORAGE_SET, binding = 2) uniform texture2D inNonLinearDepth;
-layout(set = STORAGE_SET, binding = 3, rgba16f) uniform image2D outColor;
+layout(set = STORAGE_SET, binding = 3) uniform image2D outColor;
 layout(set = STORAGE_SET, binding = 4) uniform sampler depthSampler;
 
 layout(push_constant) uniform DeferredShadingPC

--- a/res/shader/dof/combine.comp
+++ b/res/shader/dof/combine.comp
@@ -1,6 +1,7 @@
 #pragma shader_stage(compute)
 
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_image_load_formatted : require
 
 #include "../common/math.glsl"
 #include "bilateral.glsl"
@@ -8,13 +9,11 @@
 // Based on A Life of a Bokeh by Guillaume Abadie
 // https://advances.realtimerendering.com/s2018/index.htm
 
-layout(set = 0, binding = 0, rgba16f) uniform readonly image2D
-    inHalfResFgBokehWeight;
-layout(set = 0, binding = 1, rgba16f) uniform readonly image2D
-    inHalfResBgBokehWeight;
-layout(set = 0, binding = 2, r16f) uniform readonly image2D inHalfResCoC;
-layout(set = 0, binding = 3, rgba16f) uniform readonly image2D inIllumination;
-layout(set = 0, binding = 4, rgba16f) uniform writeonly image2D outIllumination;
+layout(set = 0, binding = 0) uniform readonly image2D inHalfResFgBokehWeight;
+layout(set = 0, binding = 1) uniform readonly image2D inHalfResBgBokehWeight;
+layout(set = 0, binding = 2) uniform readonly image2D inHalfResCoC;
+layout(set = 0, binding = 3) uniform readonly image2D inIllumination;
+layout(set = 0, binding = 4) uniform writeonly image2D outIllumination;
 
 vec4 upscaleBackground(ivec2 fullResCoord, float fullResCoC)
 {

--- a/res/shader/dof/dilate.comp
+++ b/res/shader/dof/dilate.comp
@@ -1,16 +1,14 @@
 #pragma shader_stage(compute)
 
 #extension GL_GOOGLE_include_directive : require
-#extension GL_KHR_shader_subgroup_basic : require
-#extension GL_KHR_shader_subgroup_arithmetic : require
+#extension GL_EXT_shader_image_load_formatted : require
 
 // Based on A Life of a Bokeh by Guillaume Abadie
 // https://advances.realtimerendering.com/s2018/index.htm
 
-layout(set = 0, binding = 0, rg16f) uniform readonly image2D inTileMinMaxCoC;
+layout(set = 0, binding = 0) uniform readonly image2D inTileMinMaxCoC;
 // TODO: Need this much precision?
-layout(set = 0, binding = 1, rg16f) uniform writeonly image2D
-    outDilatedTileMinMaxCoC;
+layout(set = 0, binding = 1) uniform writeonly image2D outDilatedTileMinMaxCoC;
 
 layout(local_size_x = 16, local_size_y = 16) in;
 void main()

--- a/res/shader/dof/flatten.comp
+++ b/res/shader/dof/flatten.comp
@@ -1,15 +1,16 @@
 #pragma shader_stage(compute)
 
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_image_load_formatted : require
 #extension GL_KHR_shader_subgroup_basic : require
 #extension GL_KHR_shader_subgroup_arithmetic : require
 
 // Based on A Life of a Bokeh by Guillaume Abadie
 // https://advances.realtimerendering.com/s2018/index.htm
 
-layout(set = 0, binding = 0, rgba16f) uniform readonly image2D inHalfResCoC;
+layout(set = 0, binding = 0) uniform readonly image2D inHalfResCoC;
 // TODO: Need this much precision?
-layout(set = 0, binding = 1, rg16f) uniform writeonly image2D outTileMinMaxCoC;
+layout(set = 0, binding = 1) uniform writeonly image2D outTileMinMaxCoC;
 
 // This might be overtly safe
 shared float subgroupMinCoCs[8 * 8];

--- a/res/shader/dof/gather.comp
+++ b/res/shader/dof/gather.comp
@@ -1,6 +1,7 @@
 #pragma shader_stage(compute)
 
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_image_load_formatted : require
 
 #include "../common/math.glsl"
 #include "../common/random.glsl"
@@ -8,12 +9,10 @@
 // Based on A Life of a Bokeh by Guillaume Abadie
 // https://advances.realtimerendering.com/s2018/index.htm
 
-layout(set = 0, binding = 0, rgba16f) uniform readonly image2D
-    inHalfResIllumination;
-layout(set = 0, binding = 1, r16f) uniform readonly image2D inHalfResCoC;
-layout(set = 0, binding = 2, rg16f) uniform readonly image2D
-    inDilatedTileMinMaxCoC;
-layout(set = 0, binding = 3, rgba16f) uniform writeonly image2D
+layout(set = 0, binding = 0) uniform readonly image2D inHalfResIllumination;
+layout(set = 0, binding = 1) uniform readonly image2D inHalfResCoC;
+layout(set = 0, binding = 2) uniform readonly image2D inDilatedTileMinMaxCoC;
+layout(set = 0, binding = 3) uniform writeonly image2D
     outHalfResBokehColorWeight;
 
 layout(push_constant) uniform GatherPC { uint frameIndex; }

--- a/res/shader/dof/setup.comp
+++ b/res/shader/dof/setup.comp
@@ -1,6 +1,7 @@
 #pragma shader_stage(compute)
 
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_image_load_formatted : require
 
 // Based on A Life of a Bokeh by Guillaume Abadie
 // https://advances.realtimerendering.com/s2018/index.htm
@@ -10,15 +11,13 @@
 #include "bilateral.glsl"
 
 layout(local_size_x = 16, local_size_y = 16) in;
-layout(set = STORAGE_SET, binding = 0, rgba16f) uniform readonly image2D
-    inIllumination;
+layout(set = STORAGE_SET, binding = 0) uniform readonly image2D inIllumination;
 layout(set = STORAGE_SET, binding = 1) uniform texture2D inNonLinearDepth;
-layout(set = STORAGE_SET, binding = 2, rgba16f) uniform image2D outIllumination;
+layout(set = STORAGE_SET, binding = 2) uniform image2D outIllumination;
 // TODO:
 // 16bits seems like a lot of precision. Can this be r8snorm storing (1-P/z)
 // with users multiplying by MaxBgdCoC?
-layout(set = STORAGE_SET, binding = 3, r16f) uniform image2D
-    outCircleOfConfusion;
+layout(set = STORAGE_SET, binding = 3) uniform image2D outCircleOfConfusion;
 layout(set = STORAGE_SET, binding = 4) uniform sampler depthSampler;
 
 layout(push_constant) uniform SetupPC

--- a/res/shader/ibl/integrate_specular_brdf.comp
+++ b/res/shader/ibl/integrate_specular_brdf.comp
@@ -1,6 +1,8 @@
 #pragma shader_stage(compute)
 
-layout(binding = 0, rg16f) uniform writeonly image2D outLut;
+#extension GL_EXT_shader_image_load_formatted : require
+
+layout(binding = 0) uniform writeonly image2D outLut;
 
 #include "../brdf.glsl"
 #include "../common/math.glsl"

--- a/res/shader/restir_di/initial_reservoirs.comp
+++ b/res/shader/restir_di/initial_reservoirs.comp
@@ -1,5 +1,6 @@
 #extension GL_EXT_nonuniform_qualifier : require
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_image_load_formatted : require
 
 #pragma shader_stage(compute)
 
@@ -15,12 +16,12 @@
 layout(push_constant) uniform RtDiInitialReservoirsPC { uint frameIndex; }
 PC;
 
-layout(set = STORAGE_SET, binding = 0, rgba8) uniform readonly image2D
+layout(set = STORAGE_SET, binding = 0) uniform readonly image2D
     inAlbedoRoughness;
-layout(set = STORAGE_SET, binding = 1, rgba16) uniform readonly image2D
+layout(set = STORAGE_SET, binding = 1) uniform readonly image2D
     inNormalMetallic;
 layout(set = STORAGE_SET, binding = 2) uniform texture2D inNonLinearDepth;
-layout(set = STORAGE_SET, binding = 3, rgba32f) uniform image2D outReservoirs;
+layout(set = STORAGE_SET, binding = 3) uniform image2D outReservoirs;
 layout(set = STORAGE_SET, binding = 4) uniform sampler depthSampler;
 
 // ReSTIR based on

--- a/res/shader/restir_di/spatial_reuse.comp
+++ b/res/shader/restir_di/spatial_reuse.comp
@@ -1,5 +1,6 @@
 #extension GL_EXT_nonuniform_qualifier : require
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_image_load_formatted : require
 
 #pragma shader_stage(compute)
 
@@ -15,14 +16,13 @@
 layout(push_constant) uniform RtDiInitialReservoirsPC { uint frameIndex; }
 PC;
 
-layout(set = STORAGE_SET, binding = 0, rgba8) uniform readonly image2D
+layout(set = STORAGE_SET, binding = 0) uniform readonly image2D
     inAlbedoRoughness;
-layout(set = STORAGE_SET, binding = 1, rgba16) uniform readonly image2D
+layout(set = STORAGE_SET, binding = 1) uniform readonly image2D
     inNormalMetallic;
 layout(set = STORAGE_SET, binding = 2) uniform texture2D inNonLinearDepth;
-layout(set = STORAGE_SET, binding = 3, rgba32f) uniform readonly image2D
-    inReservoirs;
-layout(set = STORAGE_SET, binding = 4, rgba32f) uniform image2D outReservoirs;
+layout(set = STORAGE_SET, binding = 3) uniform readonly image2D inReservoirs;
+layout(set = STORAGE_SET, binding = 4) uniform image2D outReservoirs;
 layout(set = STORAGE_SET, binding = 5) uniform sampler depthSampler;
 
 // ReSTIR based on

--- a/res/shader/rt/direct_illumination/main.rgen
+++ b/res/shader/rt/direct_illumination/main.rgen
@@ -1,6 +1,7 @@
 #extension GL_EXT_ray_tracing : require
 #extension GL_EXT_nonuniform_qualifier : require
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_image_load_formatted : require
 
 #pragma shader_stage(raygen)
 
@@ -21,16 +22,14 @@
 #include "../payload.glsl"
 #include "pc.glsl"
 
-layout(set = STORAGE_SET, binding = 0, rgba8) uniform readonly image2D
+layout(set = STORAGE_SET, binding = 0) uniform readonly image2D
     inAlbedoRoughness;
-layout(set = STORAGE_SET, binding = 1, rgba16) uniform readonly image2D
+layout(set = STORAGE_SET, binding = 1) uniform readonly image2D
     inNormalMetallic;
 layout(set = STORAGE_SET, binding = 2) uniform texture2D inNonLinearDepth;
-layout(set = STORAGE_SET, binding = 3, rg32f) uniform readonly image2D
-    inReservoirs;
-layout(set = STORAGE_SET, binding = 4, rgba32f) uniform readonly image2D
-    previousColor;
-layout(set = STORAGE_SET, binding = 5, rgba32f) uniform image2D outColor;
+layout(set = STORAGE_SET, binding = 3) uniform readonly image2D inReservoirs;
+layout(set = STORAGE_SET, binding = 4) uniform readonly image2D previousColor;
+layout(set = STORAGE_SET, binding = 5) uniform image2D outColor;
 layout(set = STORAGE_SET, binding = 6) uniform sampler depthSampler;
 
 layout(location = 0) rayPayloadEXT RayPayload payload;

--- a/res/shader/rt/reference/main.rgen
+++ b/res/shader/rt/reference/main.rgen
@@ -1,6 +1,7 @@
 #extension GL_EXT_ray_tracing : require
 #extension GL_EXT_nonuniform_qualifier : require
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_image_load_formatted : require
 
 #pragma shader_stage(raygen)
 
@@ -20,8 +21,8 @@
 #include "../payload.glsl"
 #include "rtpc.glsl"
 
-layout(set = OUTPUT_SET, binding = 0, rgba32f) uniform image2D previousColor;
-layout(set = OUTPUT_SET, binding = 1, rgba32f) uniform image2D outColor;
+layout(set = OUTPUT_SET, binding = 0) uniform image2D previousColor;
+layout(set = OUTPUT_SET, binding = 1) uniform image2D outColor;
 
 layout(location = 0) rayPayloadEXT RayPayload payload;
 

--- a/res/shader/taa_resolve.comp
+++ b/res/shader/taa_resolve.comp
@@ -1,5 +1,7 @@
 #pragma shader_stage(compute)
 
+#extension GL_EXT_shader_image_load_formatted : require
+
 // Based on
 // https://www.elopezr.com/temporal-aa-and-the-quest-for-the-holy-trail/
 // and
@@ -20,8 +22,7 @@ layout(set = STORAGE_SET, binding = 0) uniform texture2D inIllumination;
 layout(set = STORAGE_SET, binding = 1) uniform texture2D inPreviousResolved;
 layout(set = STORAGE_SET, binding = 2) uniform texture2D inVelocity;
 layout(set = STORAGE_SET, binding = 3) uniform texture2D inNonLinearDepth;
-layout(set = STORAGE_SET, binding = 4, rgba8) uniform writeonly image2D
-    outResolved;
+layout(set = STORAGE_SET, binding = 4) uniform writeonly image2D outResolved;
 layout(set = STORAGE_SET, binding = 5) uniform sampler nearestSampler;
 layout(set = STORAGE_SET, binding = 6) uniform sampler bilinearSampler;
 

--- a/res/shader/texture_debug.comp
+++ b/res/shader/texture_debug.comp
@@ -2,11 +2,12 @@
 #pragma shader_stage(compute)
 
 #extension GL_GOOGLE_include_directive : require
+#extension GL_EXT_shader_image_load_formatted : require
 
 #include "common/math.glsl"
 
 layout(binding = 0) uniform texture2D inColor;
-layout(binding = 1, rgba8) uniform writeonly image2D outColor;
+layout(binding = 1) uniform writeonly image2D outColor;
 layout(binding = 2) uniform sampler inSampler;
 
 layout(push_constant) uniform TextureDebugPC

--- a/res/shader/tone_map.comp
+++ b/res/shader/tone_map.comp
@@ -1,5 +1,7 @@
 #pragma shader_stage(compute)
 
+#extension GL_EXT_shader_image_load_formatted : require
+
 layout(push_constant) uniform ToneMapPC
 {
     float exposure;
@@ -8,8 +10,8 @@ layout(push_constant) uniform ToneMapPC
 PC;
 
 layout(local_size_x = 16, local_size_y = 16) in;
-layout(binding = 0, rgba16f) uniform readonly image2D inColor;
-layout(binding = 1, rgba8) uniform image2D outColor;
+layout(binding = 0) uniform readonly image2D inColor;
+layout(binding = 1) uniform image2D outColor;
 
 // From Krzysztof Narkowicz
 // https://knarkowicz.wordpress.com/2016/01/06/aces-filmic-tone-mapping-curve/

--- a/src/gfx/Device.cpp
+++ b/src/gfx/Device.cpp
@@ -33,6 +33,10 @@ using namespace wheels;
     vk::PhysicalDeviceFeatures2, features.geometryShader,                      \
         vk::PhysicalDeviceFeatures2, features.samplerAnisotropy,               \
         vk::PhysicalDeviceFeatures2,                                           \
+        features.shaderStorageImageReadWithoutFormat,                          \
+        vk::PhysicalDeviceFeatures2,                                           \
+        features.shaderStorageImageWriteWithoutFormat,                         \
+        vk::PhysicalDeviceFeatures2,                                           \
         features.shaderSampledImageArrayDynamicIndexing,                       \
         vk::PhysicalDeviceFeatures2, features.pipelineStatisticsQuery,         \
         vk::PhysicalDeviceVulkan12Features, descriptorIndexing,                \

--- a/src/render/rtdi/RtDiTrace.cpp
+++ b/src/render/rtdi/RtDiTrace.cpp
@@ -191,7 +191,7 @@ RtDiTrace::Output RtDiTrace::record(
         // This could be a 'normal' lower bitdepth illumination target when
         // accumulation is skipped. However, glsl needs explicit format for the
         // uniform.
-        ImageHandle illumination = _resources->images.create(
+        ret.illumination = _resources->images.create(
             accumulateImageDescription, "RtDiTrace32bit");
 
         vk::Extent3D previousExtent;
@@ -215,7 +215,7 @@ RtDiTrace::Output RtDiTrace::record(
                 _previousIllumination, "previousRtDiTrace");
 
         updateDescriptorSet(
-            WHEELS_MOV(scopeAlloc), nextFrame, input, illumination);
+            WHEELS_MOV(scopeAlloc), nextFrame, input, ret.illumination);
 
         {
             const vk::MemoryBarrier2 barrier{
@@ -242,7 +242,7 @@ RtDiTrace::Output RtDiTrace::record(
                 {input.gbuffer.depth, ImageState::RayTracingRead},
                 {input.reservoirs, ImageState::RayTracingRead},
                 {_previousIllumination, ImageState::RayTracingRead},
-                {illumination, ImageState::RayTracingReadWrite},
+                {ret.illumination, ImageState::RayTracingReadWrite},
             });
 
         const auto _s = profiler->createCpuGpuScope(cb, "  Trace");
@@ -328,51 +328,8 @@ RtDiTrace::Output RtDiTrace::record(
             renderExtent.width, renderExtent.height, 1);
 
         _resources->images.release(_previousIllumination);
-        _previousIllumination = illumination;
+        _previousIllumination = ret.illumination;
         _resources->images.preserve(_previousIllumination);
-
-        // Further passes expect 16bit illumination
-        // TODO:
-        // Remove this and return the 32bit illumination when shaders are in
-        // HLSL and 16bit/32bit texture read layout doesn't matter
-        {
-            ret.illumination =
-                createIllumination(*_resources, renderExtent, "RtDiTrace");
-
-            transition<2>(
-                *_resources, cb,
-                {
-                    {illumination, ImageState::TransferSrc},
-                    {ret.illumination, ImageState::TransferDst},
-                });
-
-            const vk::ImageSubresourceLayers layers{
-                .aspectMask = vk::ImageAspectFlagBits::eColor,
-                .mipLevel = 0,
-                .baseArrayLayer = 0,
-                .layerCount = 1};
-
-            const std::array offsets{
-                vk::Offset3D{0, 0, 0},
-                vk::Offset3D{
-                    asserted_cast<int32_t>(renderExtent.width),
-                    asserted_cast<int32_t>(renderExtent.height),
-                    1,
-                },
-            };
-            const auto blit = vk::ImageBlit{
-                .srcSubresource = layers,
-                .srcOffsets = offsets,
-                .dstSubresource = layers,
-                .dstOffsets = offsets,
-            };
-            cb.blitImage(
-                _resources->images.nativeHandle(illumination),
-                vk::ImageLayout::eTransferSrcOptimal,
-                _resources->images.nativeHandle(ret.illumination),
-                vk::ImageLayout::eTransferDstOptimal, 1, &blit,
-                vk::Filter::eLinear);
-        }
     }
 
     _accumulationDirty = false;


### PR DESCRIPTION
Seems like needless noise for modern HW, already force extra resources and blits in the renderer.