### PR TITLE
Use two part init

### DIFF
--- a/src/App.hpp
+++ b/src/App.hpp
@@ -27,7 +27,7 @@ class App
         Device::Settings device;
     };
 
-    App(const Settings &settings);
+    App(const Settings &settings) noexcept;
     ~App();
 
     App(const App &other) = delete;
@@ -35,6 +35,7 @@ class App
     App &operator=(const App &other) = delete;
     App &operator=(App &&other) = delete;
 
+    void init();
     void run();
 
   private:
@@ -101,6 +102,7 @@ class App
     wheels::TlsfAllocator _generalAlloc;
     // Separate allocator for async polling as TlsfAllocator is not thread safe
     wheels::TlsfAllocator _fileChangePollingAlloc;
+    std::filesystem::path _scenePath;
 
     InputHandler _inputHandler;
     std::unique_ptr<Window>

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -13,7 +13,7 @@ using namespace wheels;
 
 Window::Window(
     const Pair<uint32_t, uint32_t> &resolution, const char *title,
-    InputHandler *inputHandler)
+    InputHandler *inputHandler) noexcept
 : _inputHandler{inputHandler}
 , _width{resolution.first}
 , _height{resolution.second}

--- a/src/Window.hpp
+++ b/src/Window.hpp
@@ -17,7 +17,7 @@ class Window
   public:
     Window(
         const wheels::Pair<uint32_t, uint32_t> &resolution, const char *title,
-        InputHandler *inputHandler);
+        InputHandler *inputHandler) noexcept;
     ~Window();
 
     Window(const Window &other) = delete;

--- a/src/gfx/DescriptorAllocator.hpp
+++ b/src/gfx/DescriptorAllocator.hpp
@@ -13,10 +13,8 @@
 class DescriptorAllocator
 {
   public:
-    // Both alloc and device need to live as long as this
-    DescriptorAllocator(
-        wheels::Allocator &alloc, Device *device,
-        vk::DescriptorPoolCreateFlags flags = vk::DescriptorPoolCreateFlags{});
+    // alloc needs to live as long as this
+    DescriptorAllocator(wheels::Allocator &alloc) noexcept;
     // Descriptors allocated by this allocator are implicitly freed when the
     // pools are destroyed
     ~DescriptorAllocator();
@@ -25,6 +23,11 @@ class DescriptorAllocator
     DescriptorAllocator(DescriptorAllocator &&) = delete;
     DescriptorAllocator &operator=(DescriptorAllocator const &) = delete;
     DescriptorAllocator &operator=(DescriptorAllocator &&) = delete;
+
+    // device needs to live as long as this
+    void init(
+        Device *device,
+        vk::DescriptorPoolCreateFlags flags = vk::DescriptorPoolCreateFlags{});
 
     // Reset frees all allocated descriptors/sets and makes the pools available
     // for new allocations
@@ -46,6 +49,7 @@ class DescriptorAllocator
         wheels::Span<const vk::DescriptorSetLayout> layouts,
         wheels::Span<vk::DescriptorSet> output, const void *allocatePNext);
 
+    bool _initialized{false};
     Device *_device{nullptr};
     int32_t _activePool{-1};
     wheels::Array<vk::DescriptorPool> _pools;

--- a/src/gfx/Device.hpp
+++ b/src/gfx/Device.hpp
@@ -68,15 +68,15 @@ class Device
         bool robustAccess{false};
     };
 
-    Device(
-        wheels::Allocator &generalAlloc, wheels::ScopedScratch scopeAlloc,
-        GLFWwindow *window, const Settings &settings);
+    Device(wheels::Allocator &generalAlloc, const Settings &settings) noexcept;
     ~Device();
 
     Device(const Device &other) = delete;
     Device(Device &&other) = delete;
     Device &operator=(const Device &other) = delete;
     Device &operator=(Device &&other) = delete;
+
+    void init(wheels::ScopedScratch scopeAlloc, GLFWwindow *window);
 
     [[nodiscard]] vk::Instance instance() const;
     [[nodiscard]] vk::PhysicalDevice physical() const;
@@ -174,6 +174,7 @@ class Device
     void trackImage(const Image &image);
     void untrackImage(const Image &image);
 
+    bool _initialized{false};
     wheels::Allocator &_generalAlloc;
     Settings _settings;
 

--- a/src/gfx/ShaderReflection.cpp
+++ b/src/gfx/ShaderReflection.cpp
@@ -145,7 +145,7 @@ const size_t firstOpOffset = 5;
 
 void firstPass(
     Allocator &alloc, const uint32_t *words, size_t wordCount,
-    Array<SpvResult> &results, uint32_t &pushConstantMetadataId)
+    Span<SpvResult> results, uint32_t &pushConstantMetadataId)
 {
     // Collect names and types
     size_t opFirstWord = firstOpOffset;
@@ -369,7 +369,7 @@ void firstPass(
 }
 
 void secondPass(
-    const uint32_t *words, size_t wordCount, Array<SpvResult> &results)
+    const uint32_t *words, size_t wordCount, Span<SpvResult> results)
 {
     // Collect decorations
     size_t opFirstWord = firstOpOffset;
@@ -440,7 +440,7 @@ void secondPass(
 // Returns the raw size of the member, without padding to alignment
 uint32_t memberBytesize(
     const Optional<SpvType> &type, const MemberDecorations &memberDecorations,
-    const Array<SpvResult> &results)
+    Span<const SpvResult> results)
 {
     WHEELS_ASSERT(
         type.has_value() && "Unimplemented member type, probably OpTypeArray");
@@ -488,7 +488,7 @@ uint32_t memberBytesize(
 }
 
 uint32_t getPushConstantsBytesize(
-    const Array<SpvResult> &results, uint32_t metadataId)
+    Span<const SpvResult> results, uint32_t metadataId)
 {
     const SpvResult &pcResult = results[metadataId];
 
@@ -537,7 +537,7 @@ Array<DescriptorSetMetadata> &getSetMetadatas(
 }
 
 const SpvResult &getType(
-    const SpvVariable &variable, const Array<SpvResult> &results)
+    const SpvVariable &variable, Span<const SpvResult> results)
 {
     const SpvResult &typePtrResult = results[variable.typeId];
     WHEELS_ASSERT(typePtrResult.type.has_value());
@@ -569,7 +569,7 @@ vk::DescriptorType intoArrayDescriptorType(const SpvResult &typeResult)
 }
 
 bool isDynamicStorageBuffer(
-    const SpvVariable &variable, const Array<SpvResult> &results)
+    const SpvVariable &variable, Span<const SpvResult> results)
 {
     const SpvResult &type = getType(variable, results);
     if (type.name == nullptr)
@@ -595,7 +595,7 @@ bool isDynamicStorageBuffer(
 
 void fillMetadata(
     String &&name, const Decorations &decorations, const SpvVariable &variable,
-    const Array<SpvResult> &results,
+    Span<const SpvResult> results,
     HashMap<uint32_t, Array<DescriptorSetMetadata>> &metadatas)
 {
     // TODO: Generalize the common parts, pull out case noise into
@@ -691,7 +691,7 @@ void fillMetadata(
 }
 
 HashMap<uint32_t, Array<DescriptorSetMetadata>> fillDescriptorSetMetadatas(
-    ScopedScratch scopeAlloc, Allocator &alloc, const Array<SpvResult> &results)
+    ScopedScratch scopeAlloc, Allocator &alloc, Span<const SpvResult> results)
 {
     // Get counts first so we can allocate return memory exactly
     HashMap<uint32_t, uint32_t> descriptorSetBindingCounts{scopeAlloc, 16};

--- a/src/gfx/ShaderReflection.hpp
+++ b/src/gfx/ShaderReflection.hpp
@@ -34,17 +34,17 @@ using DescriptorInfo = std::variant<
 class ShaderReflection
 {
   public:
-    ShaderReflection(wheels::Allocator &alloc);
-    ShaderReflection(
-        wheels::ScopedScratch scopeAlloc, wheels::Allocator &alloc,
-        wheels::Span<const uint32_t> spvWords,
-        const wheels::HashSet<std::filesystem::path> &sourcefiles);
+    ShaderReflection(wheels::Allocator &alloc) noexcept;
     ~ShaderReflection() = default;
 
     ShaderReflection(const ShaderReflection &) = delete;
-    ShaderReflection(ShaderReflection &&) = default;
+    ShaderReflection(ShaderReflection &&other) noexcept;
     ShaderReflection &operator=(const ShaderReflection &) = delete;
-    ShaderReflection &operator=(ShaderReflection &&) = default;
+    ShaderReflection &operator=(ShaderReflection &&other) noexcept;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, wheels::Span<const uint32_t> spvWords,
+        const wheels::HashSet<std::filesystem::path> &sourcefiles);
 
     [[nodiscard]] uint32_t pushConstantsBytesize() const;
     [[nodiscard]] wheels::HashMap<
@@ -71,6 +71,8 @@ class ShaderReflection
         wheels::Span<const DescriptorInfo> descriptorInfos) const;
 
   private:
+    bool _initialized{false};
+    wheels::Allocator &_alloc;
     uint32_t _pushConstantsBytesize{0};
     wheels::HashMap<uint32_t, wheels::Array<DescriptorSetMetadata>>
         _descriptorSetMetadatas;

--- a/src/gfx/Swapchain.hpp
+++ b/src/gfx/Swapchain.hpp
@@ -50,13 +50,15 @@ struct SwapchainImage
 class Swapchain
 {
   public:
-    Swapchain(Device *device, const SwapchainConfig &config);
+    Swapchain() = default;
     ~Swapchain();
 
     Swapchain(const Swapchain &other) = delete;
     Swapchain(Swapchain &&other) = delete;
     Swapchain &operator=(const Swapchain &other) = delete;
     Swapchain &operator=(Swapchain &&other) = delete;
+
+    void init(Device *device, const SwapchainConfig &config);
 
     [[nodiscard]] SwapchainConfig const &config() const;
     [[nodiscard]] vk::Format format() const;
@@ -80,7 +82,7 @@ class Swapchain
     void createImages();
     void createFences();
 
-    // Swapchain with null device is invalid or moved
+    bool _initialized{false};
     Device *_device{nullptr};
     SwapchainConfig _config;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -95,6 +95,7 @@ int main(int argc, char *argv[])
         const App::Settings settings = parseCli(argc, argv);
 
         App app{settings};
+        app.init();
         app.run();
     }
     catch (std::exception &e)

--- a/src/render/ComputePass.hpp
+++ b/src/render/ComputePass.hpp
@@ -33,19 +33,20 @@ class ComputePass
         glm::uvec3 groupSize{16, 16, 1};
     };
 
-    ComputePass(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        DescriptorAllocator *staticDescriptorsAlloc,
-        const std::function<Shader(wheels::Allocator &)>
-            &shaderDefinitionCallback,
-        const ComputePassOptions &options = ComputePassOptions{});
-
+    ComputePass() = default;
     ~ComputePass();
 
     ComputePass(const ComputePass &other) = delete;
     ComputePass(ComputePass &&other) = delete;
     ComputePass &operator=(const ComputePass &other) = delete;
     ComputePass &operator=(ComputePass &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        DescriptorAllocator *staticDescriptorsAlloc,
+        const std::function<Shader(wheels::Allocator &)>
+            &shaderDefinitionCallback,
+        const ComputePassOptions &options = ComputePassOptions{});
 
     // Returns true if recompile happened
     bool recompileShader(
@@ -112,6 +113,7 @@ class ComputePass
         wheels::ScopedScratch scopeAlloc,
         wheels::Span<const vk::DescriptorSetLayout> externalDsLayouts = {});
 
+    bool _initialized{false};
     Device *_device{nullptr};
 
     vk::ShaderModule _shaderModule;

--- a/src/render/DebugRenderer.hpp
+++ b/src/render/DebugRenderer.hpp
@@ -22,16 +22,18 @@ class DebugRenderer
         DEBUG_DRAW_TYPES_AND_COUNT
     };
 
-    DebugRenderer(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
-        vk::DescriptorSetLayout camDSLayout);
+    DebugRenderer() = default;
     ~DebugRenderer();
 
     DebugRenderer(const DebugRenderer &other) = delete;
     DebugRenderer(DebugRenderer &&other) = delete;
     DebugRenderer &operator=(const DebugRenderer &other) = delete;
     DebugRenderer &operator=(DebugRenderer &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
+        vk::DescriptorSetLayout camDSLayout);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -67,6 +69,7 @@ class DebugRenderer
         DescriptorAllocator *staticDescriptorsAlloc);
     void createGraphicsPipeline(vk::DescriptorSetLayout camDSLayout);
 
+    bool _initialized{false};
     Device *_device{nullptr};
     RenderResources *_resources{nullptr};
 

--- a/src/render/DeferredShading.hpp
+++ b/src/render/DeferredShading.hpp
@@ -22,23 +22,24 @@ class DeferredShading
         DEBUG_DRAW_TYPES_AND_COUNT
     };
 
-    struct InputDSLayouts
-    {
-        vk::DescriptorSetLayout camera;
-        vk::DescriptorSetLayout lightClusters;
-        const WorldDSLayouts &world;
-    };
-    DeferredShading(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
-        const InputDSLayouts &dsLayouts);
-
+    DeferredShading() = default;
     ~DeferredShading() = default;
 
     DeferredShading(const DeferredShading &other) = delete;
     DeferredShading(DeferredShading &&other) = delete;
     DeferredShading &operator=(const DeferredShading &other) = delete;
     DeferredShading &operator=(DeferredShading &&other) = delete;
+
+    struct InputDSLayouts
+    {
+        vk::DescriptorSetLayout camera;
+        vk::DescriptorSetLayout lightClusters;
+        const WorldDSLayouts &world;
+    };
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
+        const InputDSLayouts &dsLayouts);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -61,6 +62,7 @@ class DeferredShading
         const World &world, const Camera &cam, const Input &input,
         uint32_t nextFrame, bool applyIbl, Profiler *profiler);
 
+    bool _initialized{false};
     RenderResources *_resources{nullptr};
     ComputePass _computePass;
 

--- a/src/render/ForwardRenderer.hpp
+++ b/src/render/ForwardRenderer.hpp
@@ -23,22 +23,24 @@ class ForwardRenderer
         Count,
     };
 
-    struct InputDSLayouts
-    {
-        vk::DescriptorSetLayout camera;
-        vk::DescriptorSetLayout lightClusters;
-        const WorldDSLayouts &world;
-    };
-    ForwardRenderer(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        DescriptorAllocator *staticDescriptorsAlloc, RenderResources *resources,
-        const InputDSLayouts &dsLayouts);
+    ForwardRenderer() = default;
     ~ForwardRenderer();
 
     ForwardRenderer(const ForwardRenderer &other) = delete;
     ForwardRenderer(ForwardRenderer &&other) = delete;
     ForwardRenderer &operator=(const ForwardRenderer &other) = delete;
     ForwardRenderer &operator=(ForwardRenderer &&other) = delete;
+
+    struct InputDSLayouts
+    {
+        vk::DescriptorSetLayout camera;
+        vk::DescriptorSetLayout lightClusters;
+        const WorldDSLayouts &world;
+    };
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        DescriptorAllocator *staticDescriptorsAlloc, RenderResources *resources,
+        const InputDSLayouts &dsLayouts);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -125,6 +127,7 @@ class ForwardRenderer
         const RenderResources &resources,
         const ForwardRenderer::RecordInOut &inOutTargets);
 
+    bool _initialized{false};
     Device *_device{nullptr};
     RenderResources *_resources{nullptr};
 

--- a/src/render/GBufferRenderer.cpp
+++ b/src/render/GBufferRenderer.cpp
@@ -45,17 +45,19 @@ struct PCBlock
 
 } // namespace
 
-GBufferRenderer::GBufferRenderer(
+void GBufferRenderer::init(
     ScopedScratch scopeAlloc, Device *device,
     DescriptorAllocator *staticDescriptorsAlloc, RenderResources *resources,
     const vk::DescriptorSetLayout camDSLayout,
     const WorldDSLayouts &worldDSLayouts)
-: _device{device}
-, _resources{resources}
 {
-    WHEELS_ASSERT(_device != nullptr);
-    WHEELS_ASSERT(_resources != nullptr);
+    WHEELS_ASSERT(!_initialized);
+    WHEELS_ASSERT(device != nullptr);
+    WHEELS_ASSERT(resources != nullptr);
     WHEELS_ASSERT(staticDescriptorsAlloc != nullptr);
+
+    _device = device;
+    _resources = resources;
 
     printf("Creating GBufferRenderer\n");
 
@@ -64,6 +66,8 @@ GBufferRenderer::GBufferRenderer(
 
     createDescriptorSets(scopeAlloc.child_scope(), staticDescriptorsAlloc);
     createGraphicsPipelines(camDSLayout, worldDSLayouts);
+
+    _initialized = true;
 }
 
 GBufferRenderer::~GBufferRenderer()
@@ -85,6 +89,8 @@ void GBufferRenderer::recompileShaders(
     const vk::DescriptorSetLayout camDSLayout,
     const WorldDSLayouts &worldDSLayouts)
 {
+    WHEELS_ASSERT(_initialized);
+
     WHEELS_ASSERT(_meshReflection.has_value());
     WHEELS_ASSERT(_fragReflection.has_value());
     if (!_meshReflection->affected(changedFiles) &&
@@ -104,6 +110,7 @@ GBufferRendererOutput GBufferRenderer::record(
     const vk::Rect2D &renderArea, BufferHandle inOutDrawStats,
     const uint32_t nextFrame, SceneStats *sceneStats, Profiler *profiler)
 {
+    WHEELS_ASSERT(_initialized);
     WHEELS_ASSERT(meshletCuller != nullptr);
     WHEELS_ASSERT(sceneStats != nullptr);
     WHEELS_ASSERT(profiler != nullptr);

--- a/src/render/GBufferRenderer.hpp
+++ b/src/render/GBufferRenderer.hpp
@@ -23,17 +23,19 @@ struct GBufferRendererOutput
 class GBufferRenderer
 {
   public:
-    GBufferRenderer(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        DescriptorAllocator *staticDescriptorsAlloc, RenderResources *resources,
-        vk::DescriptorSetLayout camDSLayout,
-        const WorldDSLayouts &worldDSLayouts);
+    GBufferRenderer() = default;
     ~GBufferRenderer();
 
     GBufferRenderer(const GBufferRenderer &other) = delete;
     GBufferRenderer(GBufferRenderer &&other) = delete;
     GBufferRenderer &operator=(const GBufferRenderer &other) = delete;
     GBufferRenderer &operator=(GBufferRenderer &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        DescriptorAllocator *staticDescriptorsAlloc, RenderResources *resources,
+        vk::DescriptorSetLayout camDSLayout,
+        const WorldDSLayouts &worldDSLayouts);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -77,6 +79,7 @@ class GBufferRenderer
         vk::DescriptorSetLayout camDSLayout,
         const WorldDSLayouts &worldDSLayouts);
 
+    bool _initialized{false};
     Device *_device{nullptr};
     RenderResources *_resources{nullptr};
 

--- a/src/render/ImGuiRenderer.hpp
+++ b/src/render/ImGuiRenderer.hpp
@@ -18,16 +18,18 @@ extern "C"
 class ImGuiRenderer
 {
   public:
-    ImGuiRenderer(
-        Device *device, RenderResources *resources,
-        const vk::Extent2D &renderExtent, GLFWwindow *window,
-        const SwapchainConfig &swapConfig);
+    ImGuiRenderer() = default;
     ~ImGuiRenderer();
 
     ImGuiRenderer(const ImGuiRenderer &other) = delete;
     ImGuiRenderer(ImGuiRenderer &&other) = delete;
     ImGuiRenderer &operator=(const ImGuiRenderer &other) = delete;
     ImGuiRenderer &operator=(ImGuiRenderer &&other) = delete;
+
+    void init(
+        Device *device, RenderResources *resources,
+        const vk::Extent2D &renderExtent, GLFWwindow *window,
+        const SwapchainConfig &swapConfig);
 
     void startFrame(Profiler *profiler);
     void endFrame(
@@ -44,6 +46,7 @@ class ImGuiRenderer
     void destroySwapchainRelated();
     void createDescriptorPool();
 
+    bool _initialized{false};
     Device *_device{nullptr};
     RenderResources *_resources{nullptr};
     vk::DescriptorPool _descriptorPool;

--- a/src/render/ImageBasedLighting.hpp
+++ b/src/render/ImageBasedLighting.hpp
@@ -12,15 +12,17 @@
 class ImageBasedLighting
 {
   public:
-    ImageBasedLighting(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        DescriptorAllocator *staticDescriptorsAlloc);
+    ImageBasedLighting() = default;
     ~ImageBasedLighting() = default;
 
     ImageBasedLighting(const ImageBasedLighting &other) = delete;
     ImageBasedLighting(ImageBasedLighting &&other) = delete;
     ImageBasedLighting &operator=(const ImageBasedLighting &other) = delete;
     ImageBasedLighting &operator=(ImageBasedLighting &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        DescriptorAllocator *staticDescriptorsAlloc);
 
     [[nodiscard]] bool isGenerated() const;
 
@@ -33,8 +35,7 @@ class ImageBasedLighting
         uint32_t nextFrame, Profiler *profiler);
 
   private:
-    void createOutputs();
-
+    bool _initialized{false};
     Device *_device{nullptr};
     ComputePass _sampleIrradiance;
     ComputePass _integrateSpecularBrdf;

--- a/src/render/LightClustering.hpp
+++ b/src/render/LightClustering.hpp
@@ -29,18 +29,19 @@ class LightClustering
         appendDefineStr(str, "LIGHT_CLUSTER_Z_SLICE_COUNT", zSlices);
     };
 
-    LightClustering(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
-        vk::DescriptorSetLayout camDSLayout,
-        const WorldDSLayouts &worldDSLayouts);
-
+    LightClustering() = default;
     ~LightClustering() = default;
 
     LightClustering(const LightClustering &other) = delete;
     LightClustering(LightClustering &&other) = delete;
     LightClustering &operator=(const LightClustering &other) = delete;
     LightClustering &operator=(LightClustering &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
+        vk::DescriptorSetLayout camDSLayout,
+        const WorldDSLayouts &worldDSLayouts);
 
     [[nodiscard]] vk::DescriptorSetLayout descriptorSetLayout() const;
 
@@ -59,6 +60,7 @@ class LightClustering
     [[nodiscard]] LightClusteringOutput createOutputs(
         const vk::Extent2D &renderExtent);
 
+    bool _initialized{false};
     RenderResources *_resources{nullptr};
     ComputePass _computePass;
 };

--- a/src/render/MeshletCuller.cpp
+++ b/src/render/MeshletCuller.cpp
@@ -288,6 +288,14 @@ BufferHandle MeshletCuller::recordGenerateList(
                 _device->properties().meshShader.maxMeshWorkGroupCount[0] &&
             "Indirect mesh dispatch group count might not fit in the "
             "supported mesh work group count");
+        // TODO:
+        // Allocate a tight buffer? Need to add destroys for unused render
+        // resources so that async loading doesn't leave a bunch of unused
+        // buffers behind.
+        WHEELS_ASSERT(
+            drawListUpperBound * 2u * static_cast<uint32_t>(sizeof(uint32_t)) <=
+                sMeshDrawListByteSize &&
+            "Draw list might not fit in the buffer");
     }
 
     String dataName{scopeAlloc};
@@ -511,11 +519,6 @@ MeshletCullerOutput MeshletCuller::recordCullList(
         worldByteOffsets.previousModelInstanceTransforms,
         worldByteOffsets.modelInstanceScales,
     }};
-
-    WHEELS_ASSERT(
-        scene.drawInstanceCount * 2u *
-            static_cast<uint32_t>(sizeof(uint32_t)) <=
-        sMeshDrawListByteSize);
 
     const vk::Buffer argumentsHandle =
         _resources->buffers.nativeHandle(input.argumentBuffer);

--- a/src/render/MeshletCuller.hpp
+++ b/src/render/MeshletCuller.hpp
@@ -24,17 +24,19 @@ struct MeshletCullerOutput
 class MeshletCuller
 {
   public:
-    MeshletCuller(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
-        const WorldDSLayouts &worldDsLayouts,
-        vk::DescriptorSetLayout camDsLayout);
+    MeshletCuller() = default;
     ~MeshletCuller() = default;
 
     MeshletCuller(const MeshletCuller &other) = delete;
     MeshletCuller(MeshletCuller &&other) = delete;
     MeshletCuller &operator=(const MeshletCuller &other) = delete;
     MeshletCuller &operator=(MeshletCuller &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
+        const WorldDSLayouts &worldDsLayouts,
+        vk::DescriptorSetLayout camDsLayout);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -75,6 +77,7 @@ class MeshletCuller
         const World &world, const Camera &cam, uint32_t nextFrame,
         const CullerInput &input, const char *debugPrefix, Profiler *profiler);
 
+    bool _initialized{false};
     Device *_device{nullptr};
     RenderResources *_resources{nullptr};
 

--- a/src/render/RenderImageCollection.cpp
+++ b/src/render/RenderImageCollection.cpp
@@ -1,8 +1,7 @@
 #include "RenderImageCollection.hpp"
 
-RenderImageCollection::RenderImageCollection(
-    wheels::Allocator &alloc, Device *device)
-: RenderResourceCollection{alloc, device}
+RenderImageCollection::RenderImageCollection(wheels::Allocator &alloc) noexcept
+: RenderResourceCollection{alloc}
 , _subresourceViews{alloc}
 {
 }
@@ -14,10 +13,13 @@ RenderImageCollection::~RenderImageCollection()
 
 void RenderImageCollection::destroyResources()
 {
-    for (auto &views : _subresourceViews)
+    if (_device != nullptr)
     {
-        _device->destroy(views);
-        views.clear();
+        for (auto &views : _subresourceViews)
+        {
+            _device->destroy(views);
+            views.clear();
+        }
     }
 
     RenderResourceCollection::destroyResources();
@@ -26,6 +28,8 @@ void RenderImageCollection::destroyResources()
 wheels::Span<const vk::ImageView> RenderImageCollection::subresourceViews(
     ImageHandle handle)
 {
+    WHEELS_ASSERT(_device != nullptr);
+
     assertValidHandle(handle);
     if (_subresourceViews.size() <= handle.index)
         _subresourceViews.resize(handle.index + 1);

--- a/src/render/RenderImageCollection.hpp
+++ b/src/render/RenderImageCollection.hpp
@@ -18,7 +18,7 @@ class RenderImageCollection
       vk::ImageMemoryBarrier2, vk::Image, VkImage, vk::ObjectType::eImage>
 {
   public:
-    RenderImageCollection(wheels::Allocator &alloc, Device *device);
+    RenderImageCollection(wheels::Allocator &alloc) noexcept;
     ~RenderImageCollection() override;
 
     RenderImageCollection(RenderImageCollection &) = delete;

--- a/src/render/RenderResources.hpp
+++ b/src/render/RenderResources.hpp
@@ -31,13 +31,15 @@ class RenderResources
         vk::Buffer, VkBuffer, vk::ObjectType::eBuffer>;
 
     // Both alloc and device need to live as long as this
-    RenderResources(wheels::Allocator &alloc, Device *device);
+    RenderResources(wheels::Allocator &alloc) noexcept;
     ~RenderResources();
 
     RenderResources(RenderResources &) = delete;
     RenderResources(RenderResources &&) = delete;
     RenderResources &operator=(RenderResources &) = delete;
     RenderResources &operator=(RenderResources &&) = delete;
+
+    void init(Device *d);
 
     // Should be called at the start of the frame so resources will get the
     // correct names set

--- a/src/render/RtReference.hpp
+++ b/src/render/RtReference.hpp
@@ -24,17 +24,19 @@ class RtReference
 
     static constexpr uint32_t sMaxBounces = 6;
 
-    RtReference(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
-        vk::DescriptorSetLayout camDSLayout,
-        const WorldDSLayouts &worldDSLayouts);
+    RtReference() = default;
     ~RtReference();
 
     RtReference(const RtReference &other) = delete;
     RtReference(RtReference &&other) = delete;
     RtReference &operator=(const RtReference &other) = delete;
     RtReference &operator=(RtReference &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
+        vk::DescriptorSetLayout camDSLayout,
+        const WorldDSLayouts &worldDSLayouts);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -78,6 +80,7 @@ class RtReference
         const WorldDSLayouts &worldDSLayouts);
     void createShaderBindingTable(wheels::ScopedScratch scopeAlloc);
 
+    bool _initialized{false};
     Device *_device{nullptr};
     RenderResources *_resources{nullptr};
 

--- a/src/render/SkyboxRenderer.hpp
+++ b/src/render/SkyboxRenderer.hpp
@@ -14,16 +14,18 @@
 class SkyboxRenderer
 {
   public:
-    SkyboxRenderer(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources, const vk::DescriptorSetLayout camDSLayout,
-        const WorldDSLayouts &worldDSLayouts);
+    SkyboxRenderer() = default;
     ~SkyboxRenderer();
 
     SkyboxRenderer(const SkyboxRenderer &other) = delete;
     SkyboxRenderer(SkyboxRenderer &&other) = delete;
     SkyboxRenderer &operator=(const SkyboxRenderer &other) = delete;
     SkyboxRenderer &operator=(SkyboxRenderer &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources, const vk::DescriptorSetLayout camDSLayout,
+        const WorldDSLayouts &worldDSLayouts);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -59,6 +61,7 @@ class SkyboxRenderer
         const vk::DescriptorSetLayout camDSLayout,
         const WorldDSLayouts &worldDSLayouts);
 
+    bool _initialized{false};
     Device *_device{nullptr};
     RenderResources *_resources{nullptr};
 

--- a/src/render/TemporalAntiAliasing.hpp
+++ b/src/render/TemporalAntiAliasing.hpp
@@ -39,16 +39,18 @@ class TemporalAntiAliasing
         VELOCITY_SAMPLING_TYPES_AND_COUNT
     };
 
-    TemporalAntiAliasing(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
-        vk::DescriptorSetLayout camDsLayout);
+    TemporalAntiAliasing() = default;
     ~TemporalAntiAliasing() = default;
 
     TemporalAntiAliasing(const TemporalAntiAliasing &other) = delete;
     TemporalAntiAliasing(TemporalAntiAliasing &&other) = delete;
     TemporalAntiAliasing &operator=(const TemporalAntiAliasing &other) = delete;
     TemporalAntiAliasing &operator=(TemporalAntiAliasing &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
+        vk::DescriptorSetLayout camDsLayout);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -76,6 +78,7 @@ class TemporalAntiAliasing
   private:
     Output createOutputs(const vk::Extent2D &size);
 
+    bool _initialized{false};
     RenderResources *_resources{nullptr};
     ComputePass _computePass;
 

--- a/src/render/TextureDebug.hpp
+++ b/src/render/TextureDebug.hpp
@@ -32,17 +32,18 @@ class TextureDebug
         TEXTURE_DEBUG_CHANNEL_TYPES_AND_COUNT
     };
 
-    TextureDebug(
-        wheels::Allocator &alloc, wheels::ScopedScratch scopeAlloc,
-        Device *device, RenderResources *resources,
-        DescriptorAllocator *staticDescriptorsAlloc);
-
+    TextureDebug(wheels::Allocator &alloc) noexcept;
     ~TextureDebug() = default;
 
     TextureDebug(const TextureDebug &other) = delete;
     TextureDebug(TextureDebug &&other) = delete;
     TextureDebug &operator=(const TextureDebug &other) = delete;
     TextureDebug &operator=(TextureDebug &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources,
+        DescriptorAllocator *staticDescriptorsAlloc);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -57,6 +58,7 @@ class TextureDebug
   private:
     ImageHandle createOutput(vk::Extent2D size);
 
+    bool _initialized{false};
     RenderResources *_resources{nullptr};
 
     ComputePass _computePass;

--- a/src/render/ToneMap.hpp
+++ b/src/render/ToneMap.hpp
@@ -14,16 +14,18 @@
 class ToneMap
 {
   public:
-    ToneMap(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources,
-        DescriptorAllocator *staticDescriptorsAlloc);
+    ToneMap() = default;
     ~ToneMap() = default;
 
     ToneMap(const ToneMap &other) = delete;
     ToneMap(ToneMap &&other) = delete;
     ToneMap &operator=(const ToneMap &other) = delete;
     ToneMap &operator=(ToneMap &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources,
+        DescriptorAllocator *staticDescriptorsAlloc);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -42,6 +44,7 @@ class ToneMap
   private:
     Output createOutputs(const vk::Extent2D &size);
 
+    bool _initialized{false};
     RenderResources *_resources{nullptr};
     ComputePass _computePass;
 

--- a/src/render/dof/DepthOfField.hpp
+++ b/src/render/dof/DepthOfField.hpp
@@ -22,17 +22,18 @@
 class DepthOfField
 {
   public:
-    DepthOfField(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
-        vk::DescriptorSetLayout cameraDsLayout);
-
+    DepthOfField() = default;
     ~DepthOfField() = default;
 
     DepthOfField(const DepthOfField &other) = delete;
     DepthOfField(DepthOfField &&other) = delete;
     DepthOfField &operator=(const DepthOfField &other) = delete;
     DepthOfField &operator=(DepthOfField &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
+        vk::DescriptorSetLayout cameraDsLayout);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -49,6 +50,7 @@ class DepthOfField
         Profiler *profiler);
 
   private:
+    bool _initialized{false};
     RenderResources *_resources{nullptr};
 
     DepthOfFieldSetup _setupPass;

--- a/src/render/dof/DepthOfFieldCombine.cpp
+++ b/src/render/dof/DepthOfFieldCombine.cpp
@@ -38,15 +38,17 @@ ComputePass::Shader shaderDefinitionCallback(Allocator &alloc)
 
 } // namespace
 
-DepthOfFieldCombine::DepthOfFieldCombine(
+void DepthOfFieldCombine::init(
     ScopedScratch scopeAlloc, Device *device, RenderResources *resources,
     DescriptorAllocator *staticDescriptorsAlloc)
-: _resources{resources}
-, _computePass{
-      WHEELS_MOV(scopeAlloc), device, staticDescriptorsAlloc,
-      shaderDefinitionCallback}
 {
-    WHEELS_ASSERT(_resources != nullptr);
+    WHEELS_ASSERT(_resources == nullptr);
+    WHEELS_ASSERT(resources != nullptr);
+
+    _resources = resources;
+    _computePass.init(
+        WHEELS_MOV(scopeAlloc), device, staticDescriptorsAlloc,
+        shaderDefinitionCallback);
 }
 
 void DepthOfFieldCombine::recompileShaders(
@@ -61,6 +63,7 @@ DepthOfFieldCombine::Output DepthOfFieldCombine::record(
     ScopedScratch scopeAlloc, vk::CommandBuffer cb, const Input &input,
     const uint32_t nextFrame, Profiler *profiler)
 {
+    WHEELS_ASSERT(_resources != nullptr);
     WHEELS_ASSERT(profiler != nullptr);
 
     Output ret;

--- a/src/render/dof/DepthOfFieldCombine.hpp
+++ b/src/render/dof/DepthOfFieldCombine.hpp
@@ -19,17 +19,18 @@
 class DepthOfFieldCombine
 {
   public:
-    DepthOfFieldCombine(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources,
-        DescriptorAllocator *staticDescriptorsAlloc);
-
+    DepthOfFieldCombine() = default;
     ~DepthOfFieldCombine() = default;
 
     DepthOfFieldCombine(const DepthOfFieldCombine &other) = delete;
     DepthOfFieldCombine(DepthOfFieldCombine &&other) = delete;
     DepthOfFieldCombine &operator=(const DepthOfFieldCombine &other) = delete;
     DepthOfFieldCombine &operator=(DepthOfFieldCombine &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources,
+        DescriptorAllocator *staticDescriptorsAlloc);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,

--- a/src/render/dof/DepthOfFieldDilate.cpp
+++ b/src/render/dof/DepthOfFieldDilate.cpp
@@ -37,21 +37,27 @@ ComputePass::Shader shaderDefinitionCallback(Allocator &alloc)
 
 } // namespace
 
-DepthOfFieldDilate::DepthOfFieldDilate(
+void DepthOfFieldDilate::init(
     ScopedScratch scopeAlloc, Device *device, RenderResources *resources,
     DescriptorAllocator *staticDescriptorsAlloc)
-: _resources{resources}
-, _computePass{
-      WHEELS_MOV(scopeAlloc), device, staticDescriptorsAlloc,
-      shaderDefinitionCallback}
 {
-    WHEELS_ASSERT(_resources != nullptr);
+    WHEELS_ASSERT(!_initialized);
+    WHEELS_ASSERT(resources != nullptr);
+
+    _resources = resources;
+    _computePass.init(
+        WHEELS_MOV(scopeAlloc), device, staticDescriptorsAlloc,
+        shaderDefinitionCallback);
+
+    _initialized = true;
 }
 
 void DepthOfFieldDilate::recompileShaders(
     wheels::ScopedScratch scopeAlloc,
     const HashSet<std::filesystem::path> &changedFiles)
 {
+    WHEELS_ASSERT(_initialized);
+
     _computePass.recompileShader(
         WHEELS_MOV(scopeAlloc), changedFiles, shaderDefinitionCallback);
 }
@@ -60,6 +66,7 @@ DepthOfFieldDilate::Output DepthOfFieldDilate::record(
     ScopedScratch scopeAlloc, vk::CommandBuffer cb, ImageHandle tileMinMaxCoC,
     const uint32_t nextFrame, Profiler *profiler)
 {
+    WHEELS_ASSERT(_initialized);
     WHEELS_ASSERT(profiler != nullptr);
 
     Output ret;

--- a/src/render/dof/DepthOfFieldDilate.hpp
+++ b/src/render/dof/DepthOfFieldDilate.hpp
@@ -18,17 +18,18 @@
 class DepthOfFieldDilate
 {
   public:
-    DepthOfFieldDilate(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources,
-        DescriptorAllocator *staticDescriptorsAlloc);
-
+    DepthOfFieldDilate() = default;
     ~DepthOfFieldDilate() = default;
 
     DepthOfFieldDilate(const DepthOfFieldDilate &other) = delete;
     DepthOfFieldDilate(DepthOfFieldDilate &&other) = delete;
     DepthOfFieldDilate &operator=(const DepthOfFieldDilate &other) = delete;
     DepthOfFieldDilate &operator=(DepthOfFieldDilate &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources,
+        DescriptorAllocator *staticDescriptorsAlloc);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -42,6 +43,7 @@ class DepthOfFieldDilate
         wheels::ScopedScratch scopeAlloc, vk::CommandBuffer cb,
         ImageHandle tileMinMaxCoC, uint32_t nextFrame, Profiler *profiler);
 
+    bool _initialized{false};
     RenderResources *_resources{nullptr};
     ComputePass _computePass;
 };

--- a/src/render/dof/DepthOfFieldFlatten.cpp
+++ b/src/render/dof/DepthOfFieldFlatten.cpp
@@ -40,21 +40,27 @@ ComputePass::Shader shaderDefinitionCallback(Allocator &alloc)
 
 } // namespace
 
-DepthOfFieldFlatten::DepthOfFieldFlatten(
+void DepthOfFieldFlatten::init(
     ScopedScratch scopeAlloc, Device *device, RenderResources *resources,
     DescriptorAllocator *staticDescriptorsAlloc)
-: _resources{resources}
-, _computePass{
-      WHEELS_MOV(scopeAlloc), device, staticDescriptorsAlloc,
-      shaderDefinitionCallback}
 {
-    WHEELS_ASSERT(_resources != nullptr);
+    WHEELS_ASSERT(!_initialized);
+    WHEELS_ASSERT(resources != nullptr);
+
+    _resources = resources;
+    _computePass.init(
+        WHEELS_MOV(scopeAlloc), device, staticDescriptorsAlloc,
+        shaderDefinitionCallback);
+
+    _initialized = true;
 }
 
 void DepthOfFieldFlatten::recompileShaders(
     wheels::ScopedScratch scopeAlloc,
     const HashSet<std::filesystem::path> &changedFiles)
 {
+    WHEELS_ASSERT(_initialized);
+
     _computePass.recompileShader(
         WHEELS_MOV(scopeAlloc), changedFiles, shaderDefinitionCallback);
 }
@@ -64,6 +70,7 @@ DepthOfFieldFlatten::Output DepthOfFieldFlatten::record(
     ImageHandle halfResCircleOfConfusion, const uint32_t nextFrame,
     Profiler *profiler)
 {
+    WHEELS_ASSERT(_initialized);
     WHEELS_ASSERT(profiler != nullptr);
 
     Output ret;

--- a/src/render/dof/DepthOfFieldFlatten.hpp
+++ b/src/render/dof/DepthOfFieldFlatten.hpp
@@ -18,17 +18,18 @@
 class DepthOfFieldFlatten
 {
   public:
-    DepthOfFieldFlatten(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources,
-        DescriptorAllocator *staticDescriptorsAlloc);
-
+    DepthOfFieldFlatten() = default;
     ~DepthOfFieldFlatten() = default;
 
     DepthOfFieldFlatten(const DepthOfFieldFlatten &other) = delete;
     DepthOfFieldFlatten(DepthOfFieldFlatten &&other) = delete;
     DepthOfFieldFlatten &operator=(const DepthOfFieldFlatten &other) = delete;
     DepthOfFieldFlatten &operator=(DepthOfFieldFlatten &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources,
+        DescriptorAllocator *staticDescriptorsAlloc);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -43,6 +44,7 @@ class DepthOfFieldFlatten
         ImageHandle halfResCircleOfConfusion, uint32_t nextFrame,
         Profiler *profiler);
 
+    bool _initialized{false};
     RenderResources *_resources{nullptr};
     ComputePass _computePass;
 };

--- a/src/render/dof/DepthOfFieldGather.hpp
+++ b/src/render/dof/DepthOfFieldGather.hpp
@@ -25,17 +25,18 @@ class DepthOfFieldGather
         GatherType_Count,
     };
 
-    DepthOfFieldGather(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources,
-        DescriptorAllocator *staticDescriptorsAlloc);
-
+    DepthOfFieldGather() = default;
     ~DepthOfFieldGather() = default;
 
     DepthOfFieldGather(const DepthOfFieldGather &other) = delete;
     DepthOfFieldGather(DepthOfFieldGather &&other) = delete;
     DepthOfFieldGather &operator=(const DepthOfFieldGather &other) = delete;
     DepthOfFieldGather &operator=(DepthOfFieldGather &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources,
+        DescriptorAllocator *staticDescriptorsAlloc);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -56,6 +57,7 @@ class DepthOfFieldGather
         const Input &input, GatherType gatherType, uint32_t nextFrame,
         Profiler *profiler);
 
+    bool _initialized{false};
     RenderResources *_resources{nullptr};
 
     ComputePass _backgroundPass;

--- a/src/render/dof/DepthOfFieldSetup.hpp
+++ b/src/render/dof/DepthOfFieldSetup.hpp
@@ -19,17 +19,18 @@
 class DepthOfFieldSetup
 {
   public:
-    DepthOfFieldSetup(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
-        vk::DescriptorSetLayout camDsLayout);
-
+    DepthOfFieldSetup() = default;
     ~DepthOfFieldSetup() = default;
 
     DepthOfFieldSetup(const DepthOfFieldSetup &other) = delete;
     DepthOfFieldSetup(DepthOfFieldSetup &&other) = delete;
     DepthOfFieldSetup &operator=(const DepthOfFieldSetup &other) = delete;
     DepthOfFieldSetup &operator=(DepthOfFieldSetup &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
+        vk::DescriptorSetLayout camDsLayout);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -51,6 +52,7 @@ class DepthOfFieldSetup
         const Camera &cam, const Input &input, uint32_t nextFrame,
         Profiler *profiler);
 
+    bool _initialized{false};
     RenderResources *_resources{nullptr};
     ComputePass _computePass;
 };

--- a/src/render/rtdi/RtDiInitialReservoirs.cpp
+++ b/src/render/rtdi/RtDiInitialReservoirs.cpp
@@ -76,21 +76,25 @@ StaticArray<vk::DescriptorSetLayout, BindingSetCount - 1> externalDsLayouts(
 
 } // namespace
 
-RtDiInitialReservoirs::RtDiInitialReservoirs(
+void RtDiInitialReservoirs::init(
     ScopedScratch scopeAlloc, Device *device, RenderResources *resources,
     DescriptorAllocator *staticDescriptorsAlloc,
     const InputDSLayouts &dsLayouts)
-: _resources{resources}
-, _computePass{
-      WHEELS_MOV(scopeAlloc), device, staticDescriptorsAlloc,
-      [&dsLayouts](Allocator &alloc)
-      { return shaderDefinitionCallback(alloc, dsLayouts.world); },
-      ComputePassOptions{
-          .storageSetIndex = StorageBindingSet,
-          .externalDsLayouts = externalDsLayouts(dsLayouts),
-      }}
 {
-    WHEELS_ASSERT(_resources != nullptr);
+    WHEELS_ASSERT(!_initialized);
+    WHEELS_ASSERT(resources != nullptr);
+
+    _resources = resources;
+    _computePass.init(
+        WHEELS_MOV(scopeAlloc), device, staticDescriptorsAlloc,
+        [&dsLayouts](Allocator &alloc)
+        { return shaderDefinitionCallback(alloc, dsLayouts.world); },
+        ComputePassOptions{
+            .storageSetIndex = StorageBindingSet,
+            .externalDsLayouts = externalDsLayouts(dsLayouts),
+        });
+
+    _initialized = true;
 }
 
 bool RtDiInitialReservoirs::recompileShaders(
@@ -98,6 +102,8 @@ bool RtDiInitialReservoirs::recompileShaders(
     const HashSet<std::filesystem::path> &changedFiles,
     const InputDSLayouts &dsLayouts)
 {
+    WHEELS_ASSERT(_initialized);
+
     return _computePass.recompileShader(
         WHEELS_MOV(scopeAlloc), changedFiles,
         [&dsLayouts](Allocator &alloc)
@@ -110,6 +116,7 @@ RtDiInitialReservoirs::Output RtDiInitialReservoirs::record(
     const Camera &cam, const GBufferRendererOutput &gbuffer,
     const uint32_t nextFrame, Profiler *profiler)
 {
+    WHEELS_ASSERT(_initialized);
     WHEELS_ASSERT(profiler != nullptr);
 
     _frameIndex = ++_frameIndex % sFramePeriod;

--- a/src/render/rtdi/RtDiInitialReservoirs.hpp
+++ b/src/render/rtdi/RtDiInitialReservoirs.hpp
@@ -15,16 +15,7 @@
 class RtDiInitialReservoirs
 {
   public:
-    struct InputDSLayouts
-    {
-        vk::DescriptorSetLayout camera;
-        const WorldDSLayouts &world;
-    };
-    RtDiInitialReservoirs(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
-        const InputDSLayouts &dsLayouts);
-
+    RtDiInitialReservoirs() = default;
     ~RtDiInitialReservoirs() = default;
 
     RtDiInitialReservoirs(const RtDiInitialReservoirs &other) = delete;
@@ -32,6 +23,16 @@ class RtDiInitialReservoirs
     RtDiInitialReservoirs &operator=(const RtDiInitialReservoirs &other) =
         delete;
     RtDiInitialReservoirs &operator=(RtDiInitialReservoirs &&other) = delete;
+
+    struct InputDSLayouts
+    {
+        vk::DescriptorSetLayout camera;
+        const WorldDSLayouts &world;
+    };
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
+        const InputDSLayouts &dsLayouts);
 
     // Returns true if recompile happened
     bool recompileShaders(
@@ -49,6 +50,7 @@ class RtDiInitialReservoirs
         const GBufferRendererOutput &gbuffer, uint32_t nextFrame,
         Profiler *profiler);
 
+    bool _initialized{false};
     RenderResources *_resources{nullptr};
     ComputePass _computePass;
 

--- a/src/render/rtdi/RtDiSpatialReuse.hpp
+++ b/src/render/rtdi/RtDiSpatialReuse.hpp
@@ -15,22 +15,23 @@
 class RtDiSpatialReuse
 {
   public:
-    struct InputDSLayouts
-    {
-        vk::DescriptorSetLayout camera;
-        const WorldDSLayouts &world;
-    };
-    RtDiSpatialReuse(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
-        const InputDSLayouts &dsLayouts);
-
+    RtDiSpatialReuse() = default;
     ~RtDiSpatialReuse() = default;
 
     RtDiSpatialReuse(const RtDiSpatialReuse &other) = delete;
     RtDiSpatialReuse(RtDiSpatialReuse &&other) = delete;
     RtDiSpatialReuse &operator=(const RtDiSpatialReuse &other) = delete;
     RtDiSpatialReuse &operator=(RtDiSpatialReuse &&other) = delete;
+
+    struct InputDSLayouts
+    {
+        vk::DescriptorSetLayout camera;
+        const WorldDSLayouts &world;
+    };
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
+        const InputDSLayouts &dsLayouts);
 
     // Returns true if recompile happened
     bool recompileShaders(
@@ -52,6 +53,7 @@ class RtDiSpatialReuse
         const World &world, const Camera &cam, const Input &input,
         uint32_t nextFrame, Profiler *profiler);
 
+    bool _initialized{false};
     RenderResources *_resources{nullptr};
     ComputePass _computePass;
 

--- a/src/render/rtdi/RtDiTrace.hpp
+++ b/src/render/rtdi/RtDiTrace.hpp
@@ -21,17 +21,19 @@ class RtDiTrace
         DEBUG_DRAW_TYPES_AND_COUNT
     };
 
-    RtDiTrace(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
-        vk::DescriptorSetLayout camDSLayout,
-        const WorldDSLayouts &worldDSLayouts);
+    RtDiTrace() = default;
     ~RtDiTrace();
 
     RtDiTrace(const RtDiTrace &other) = delete;
     RtDiTrace(RtDiTrace &&other) = delete;
     RtDiTrace &operator=(const RtDiTrace &other) = delete;
     RtDiTrace &operator=(RtDiTrace &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
+        vk::DescriptorSetLayout camDSLayout,
+        const WorldDSLayouts &worldDSLayouts);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -74,6 +76,7 @@ class RtDiTrace
         const WorldDSLayouts &worldDSLayouts);
     void createShaderBindingTable(wheels::ScopedScratch scopeAlloc);
 
+    bool _initialized{false};
     Device *_device{nullptr};
     RenderResources *_resources{nullptr};
 

--- a/src/render/rtdi/RtDirectIllumination.hpp
+++ b/src/render/rtdi/RtDirectIllumination.hpp
@@ -21,17 +21,19 @@ class RtDirectIllumination
         DEBUG_DRAW_TYPES_AND_COUNT
     };
 
-    RtDirectIllumination(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
-        vk::DescriptorSetLayout camDSLayout,
-        const WorldDSLayouts &worldDSLayouts);
+    RtDirectIllumination() = default;
     ~RtDirectIllumination() = default;
 
     RtDirectIllumination(const RtDirectIllumination &other) = delete;
     RtDirectIllumination(RtDirectIllumination &&other) = delete;
     RtDirectIllumination &operator=(const RtDirectIllumination &other) = delete;
     RtDirectIllumination &operator=(RtDirectIllumination &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RenderResources *resources, DescriptorAllocator *staticDescriptorsAlloc,
+        vk::DescriptorSetLayout camDSLayout,
+        const WorldDSLayouts &worldDSLayouts);
 
     void recompileShaders(
         wheels::ScopedScratch scopeAlloc,
@@ -49,6 +51,7 @@ class RtDirectIllumination
     void releasePreserved();
 
   private:
+    bool _initialized{false};
     RenderResources *_resources{nullptr};
 
     bool _doSpatialReuse{true};

--- a/src/scene/Accessors.cpp
+++ b/src/scene/Accessors.cpp
@@ -7,7 +7,7 @@
 using namespace glm;
 
 TimeAccessor::TimeAccessor(
-    const float *data, uint32_t count, const Interval &interval)
+    const float *data, uint32_t count, const Interval &interval) noexcept
 : _data{data}
 , _count{count}
 , _interval{interval}
@@ -71,7 +71,7 @@ KeyFrameInterpolation TimeAccessor::interpolation(float timeS) const
 }
 
 template <>
-ValueAccessor<vec3>::ValueAccessor(const uint8_t *data, uint32_t count)
+ValueAccessor<vec3>::ValueAccessor(const uint8_t *data, uint32_t count) noexcept
 : _data{data}
 , _count{count}
 {
@@ -87,7 +87,7 @@ template <> vec3 ValueAccessor<vec3>::read(uint32_t index) const
 }
 
 template <>
-ValueAccessor<quat>::ValueAccessor(const uint8_t *data, uint32_t count)
+ValueAccessor<quat>::ValueAccessor(const uint8_t *data, uint32_t count) noexcept
 : _data{data}
 , _count{count}
 {

--- a/src/scene/Accessors.hpp
+++ b/src/scene/Accessors.hpp
@@ -21,7 +21,8 @@ class TimeAccessor
         float startTimeS{0.f};
         float endTimeS{0.f};
     };
-    TimeAccessor(const float *data, uint32_t count, const Interval &interval);
+    TimeAccessor(
+        const float *data, uint32_t count, const Interval &interval) noexcept;
 
     float endTimeS() const;
     KeyFrameInterpolation interpolation(float timeS) const;
@@ -38,7 +39,7 @@ template <typename T> class ValueAccessor
 {
   public:
     // Count is for vector elements, not individual float
-    ValueAccessor(const uint8_t *data, uint32_t count);
+    ValueAccessor(const uint8_t *data, uint32_t count) noexcept;
 
     T read(uint32_t index) const;
 

--- a/src/scene/Camera.hpp
+++ b/src/scene/Camera.hpp
@@ -83,9 +83,7 @@ class Camera
   public:
     static constexpr const char *sCameraBindingName = "camera";
 
-    Camera(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        RingBuffer *constantsRing, DescriptorAllocator *staticDescriptorsAlloc);
+    Camera() = default;
     ~Camera();
 
     Camera(const Camera &other) = delete;
@@ -93,7 +91,9 @@ class Camera
     Camera &operator=(const Camera &other) = delete;
     Camera &operator=(Camera &&other) = delete;
 
-    void init(const CameraTransform &transform, const CameraParameters &params);
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RingBuffer *constantsRing, DescriptorAllocator *staticDescriptorsAlloc);
     void endFrame();
 
     void lookAt(const CameraTransform &transform);
@@ -133,6 +133,7 @@ class Camera
     void updateFrustumPlanes(const FrustumCorners &corners);
 
     Device *_device{nullptr};
+    bool _initialized{false};
     RingBuffer *_constantsRing{nullptr};
 
     CameraTransform _transform;

--- a/src/scene/DeferredLoadingContext.hpp
+++ b/src/scene/DeferredLoadingContext.hpp
@@ -81,10 +81,7 @@ struct MeshCacheHeader
 class DeferredLoadingContext
 {
   public:
-    DeferredLoadingContext(
-        Device *device, std::filesystem::path sceneDir,
-        std::filesystem::file_time_type sceneWriteTime,
-        const tinygltf::Model &gltfModel);
+    DeferredLoadingContext() noexcept;
     ~DeferredLoadingContext();
 
     DeferredLoadingContext(const DeferredLoadingContext &) = delete;
@@ -92,7 +89,13 @@ class DeferredLoadingContext
     DeferredLoadingContext &operator=(const DeferredLoadingContext &) = delete;
     DeferredLoadingContext &operator=(DeferredLoadingContext &&) = delete;
 
+    void init(
+        Device *inDevice, std::filesystem::path inSceneDir,
+        std::filesystem::file_time_type inSceneWriteTime,
+        const tinygltf::Model &inGltfModel);
+
     void launch();
+    void kill();
 
     UploadedGeometryData uploadGeometryData(
         const MeshCacheHeader &cacheHeader,
@@ -102,6 +105,7 @@ class DeferredLoadingContext
     // Make worker context private?
     // Make shared context private and access through methods that handle
     // mutexes?
+    bool initialized{false};
     Device *device{nullptr};
     std::filesystem::path sceneDir;
     std::filesystem::file_time_type sceneWriteTime;

--- a/src/scene/Texture.hpp
+++ b/src/scene/Texture.hpp
@@ -21,7 +21,7 @@ struct Image;
 class Texture
 {
   public:
-    Texture(Device *device);
+    Texture() noexcept = default;
     virtual ~Texture();
 
     Texture(const Texture &other) = delete;
@@ -33,6 +33,8 @@ class Texture
     [[nodiscard]] virtual vk::Image nativeHandle() const;
 
   protected:
+    void init(Device *device);
+
     void destroy();
 
     // Texture with null device is invalid or moved
@@ -45,7 +47,7 @@ class Texture2D : public Texture
   public:
     // The image is ready and stagingBuffer can be freed once cb is submitted
     // and has finished executing.
-    Texture2D(
+    void init(
         wheels::ScopedScratch scopeAlloc, Device *device,
         const std::filesystem::path &path, vk::CommandBuffer cb,
         const Buffer &stagingBuffer, bool mipmap,
@@ -57,15 +59,17 @@ class Texture2D : public Texture
 class TextureCubemap : public Texture
 {
   public:
-    TextureCubemap(
-        wheels::ScopedScratch scopeAlloc, Device *device,
-        const std::filesystem::path &path);
+    TextureCubemap() noexcept = default;
     ~TextureCubemap() override;
 
     TextureCubemap(const TextureCubemap &other) = delete;
     TextureCubemap(TextureCubemap &&other) noexcept;
     TextureCubemap &operator=(const TextureCubemap &other) = delete;
     TextureCubemap &operator=(TextureCubemap &&other) noexcept;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        const std::filesystem::path &path);
 
     [[nodiscard]] vk::DescriptorImageInfo imageInfo() const override;
 

--- a/src/scene/World.hpp
+++ b/src/scene/World.hpp
@@ -14,16 +14,17 @@
 class World
 {
   public:
-    World(
-        wheels::Allocator &generalAlloc, wheels::ScopedScratch scopeAlloc,
-        Device *device, RingBuffer *constantsRing,
-        const std::filesystem::path &scene);
+    World(wheels::Allocator &generalAlloc) noexcept;
     ~World();
 
     World(const World &other) = delete;
     World(World &&other) = delete;
     World &operator=(const World &other) = delete;
     World &operator=(World &&other) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        RingBuffer *constantsRing, const std::filesystem::path &scene);
 
     void startFrame();
     void endFrame();
@@ -73,6 +74,7 @@ class World
     // Pimpl to isolate heavy includes within the World CU
     class Impl;
     std::unique_ptr<Impl> _impl;
+    bool _initialized{false};
 };
 
 #endif // PROSPER_SCENE_WORLD_HPP

--- a/src/scene/WorldData.hpp
+++ b/src/scene/WorldData.hpp
@@ -34,16 +34,17 @@ class WorldData
         RingBuffer *constantsRing{nullptr};
         RingBuffer *lightDataRing{nullptr};
     };
-    WorldData(
-        wheels::Allocator &generalAlloc, wheels::ScopedScratch scopeAlloc,
-        Device *device, const RingBuffers &ringBuffers,
-        const std::filesystem::path &scene);
+    WorldData(wheels::Allocator &generalAlloc) noexcept;
     ~WorldData();
 
     WorldData(const WorldData &) = delete;
     WorldData(WorldData &&) = delete;
     WorldData &operator=(const WorldData &) = delete;
     WorldData &operator=(WorldData &&) = delete;
+
+    void init(
+        wheels::ScopedScratch scopeAlloc, Device *device,
+        const RingBuffers &ringBuffers, const std::filesystem::path &scene);
 
     void uploadMeshDatas(wheels::ScopedScratch scopeAlloc, uint32_t nextFrame);
     void uploadMaterialDatas(uint32_t nextFrame);
@@ -56,6 +57,7 @@ class WorldData
   private:
     wheels::Allocator &_generalAlloc;
     wheels::LinearAllocator _linearAlloc;
+    bool _initialized{false};
     Device *_device{nullptr};
     DescriptorAllocator _descriptorAllocator;
 
@@ -102,7 +104,7 @@ class WorldData
     WorldDSLayouts _dsLayouts;
     WorldDescriptorSets _descriptorSets;
 
-    std::unique_ptr<RingBuffer> _modelInstanceTransformsRing;
+    RingBuffer _modelInstanceTransformsRing;
 
     wheels::Optional<DeferredLoadingContext> _deferredLoadingContext;
     uint32_t _deferredLoadingGeneralAllocatorHighWatermark{0};

--- a/src/utils/Profiler.hpp
+++ b/src/utils/Profiler.hpp
@@ -59,7 +59,7 @@ class GpuFrameProfiler
         wheels::Optional<PipelineStatistics> stats;
     };
 
-    GpuFrameProfiler(wheels::Allocator &alloc, Device *device);
+    GpuFrameProfiler(wheels::Allocator &alloc) noexcept;
     ~GpuFrameProfiler();
 
     GpuFrameProfiler(GpuFrameProfiler const &) = delete;
@@ -68,6 +68,7 @@ class GpuFrameProfiler
     GpuFrameProfiler &operator=(GpuFrameProfiler &&other) noexcept;
 
   protected:
+    void init(Device *device);
     void startFrame();
     void endFrame(vk::CommandBuffer cb);
 
@@ -80,7 +81,7 @@ class GpuFrameProfiler
     [[nodiscard]] wheels::Array<ScopeData> getData(wheels::Allocator &alloc);
 
   private:
-    Device *_device;
+    Device *_device{nullptr};
     Buffer _timestampBuffer;
     Buffer _statisticsBuffer;
     QueryPools _pools;
@@ -121,7 +122,7 @@ class CpuFrameProfiler
         float millis{0.f};
     };
 
-    CpuFrameProfiler(wheels::Allocator &alloc);
+    CpuFrameProfiler(wheels::Allocator &alloc) noexcept;
     ~CpuFrameProfiler() = default;
 
     CpuFrameProfiler(CpuFrameProfiler const &) = delete;
@@ -184,7 +185,7 @@ class Profiler
         wheels::Optional<PipelineStatistics> gpuStats;
     };
 
-    Profiler(wheels::Allocator &alloc, Device *device);
+    Profiler(wheels::Allocator &alloc) noexcept;
     ~Profiler() = default;
 
     // Assume one profiler that is initialized in place
@@ -192,6 +193,8 @@ class Profiler
     Profiler(Profiler &&) = delete;
     Profiler &operator=(Profiler const &) = delete;
     Profiler &operator=(Profiler &&) = delete;
+
+    void init(Device *device);
 
     // Should be called before startGpuFrame, whenever the cpu frame loop starts
     void startCpuFrame();
@@ -232,6 +235,7 @@ class Profiler
         EndGpuCalled,
     };
 
+    bool _initialized{false};
     DebugState _debugState{DebugState::NewFrame};
 
     wheels::Allocator &_alloc;

--- a/todo.txt
+++ b/todo.txt
@@ -54,9 +54,6 @@
     - Could get too messy and brittle
 - Pipeline cache
   - https://zeux.io/2019/07/17/serializing-pipeline-cache/
-- Fix init/load time crashes causing broken teardown and VMA asserts masking the
-  actual root cause throws
-  - Non-throwing ctors and separate init to make sure cleanup always happens?
 - Have texture and mesh cache both next to the scene instead of textures being
   next to the textures?
 - Compile time loops in mesh shader


### PR DESCRIPTION
Ctors throwing wasn't working very well so let's try noexcept ctors and separate init instead. Now cleanup should still work when the stack is unwound and the code still seems clear enough. 