### PR TITLE
Have all submodels of a model in the same BLAS

### DIFF
--- a/res/shader/rt/direct_illumination/main.rgen
+++ b/res/shader/rt/direct_illumination/main.rgen
@@ -42,12 +42,12 @@ float shadow(vec3 p, vec3 l, float tMin, float lDist)
     const uint mask = 0xFF;
     const uint flags = gl_RayFlagsTerminateOnFirstHitEXT;
 
-    payload.instanceCustomIndex = MISS_INDEX;
+    payload.drawInstanceIndex = MISS_INDEX;
     payload.randomSeed = pcg(pcg_state.x ^ pcg_state.y);
 
     traceRayEXT(as, flags, mask, 0, 0, 0, p, tMin, l, lDist, 0);
 
-    return payload.instanceCustomIndex == MISS_INDEX ? 1. : 0.;
+    return payload.drawInstanceIndex == MISS_INDEX ? 1. : 0.;
 }
 
 vec3 evaluateDirectLighting(VisibleSurface surface)

--- a/res/shader/rt/payload.glsl
+++ b/res/shader/rt/payload.glsl
@@ -3,7 +3,7 @@
 
 struct RayPayload
 {
-    uint instanceCustomIndex;
+    uint drawInstanceIndex;
     uint primitiveID;
     vec2 baryCoord;
     uint randomSeed;

--- a/res/shader/rt/reference/main.rgen
+++ b/res/shader/rt/reference/main.rgen
@@ -44,12 +44,12 @@ float shadow(vec3 p, vec3 l, float tMin, float lDist)
     const uint mask = 0xFF;
     const uint flags = gl_RayFlagsTerminateOnFirstHitEXT;
 
-    payload.instanceCustomIndex = MISS_INDEX;
+    payload.drawInstanceIndex = MISS_INDEX;
     payload.randomSeed = pcg(pcg_state.x ^ pcg_state.y);
 
     traceRayEXT(as, flags, mask, 0, 0, 0, p, tMin, l, lDist, 0);
 
-    return payload.instanceCustomIndex == MISS_INDEX ? 1. : 0.;
+    return payload.drawInstanceIndex == MISS_INDEX ? 1. : 0.;
 }
 
 RayPayload traceClosest(Ray ray)
@@ -58,7 +58,7 @@ RayPayload traceClosest(Ray ray)
     const uint flags = gl_RayFlagsNoneEXT; // We want anyhit here
 
     // Tight scope for payload use as having it dangle seems to prevent reuse
-    payload.instanceCustomIndex = MISS_INDEX;
+    payload.drawInstanceIndex = MISS_INDEX;
     payload.primitiveID = MISS_INDEX;
     payload.baryCoord = vec2(0);
     payload.randomSeed = pcg(pcg_state.x ^ pcg_state.z);
@@ -66,7 +66,7 @@ RayPayload traceClosest(Ray ray)
     traceRayEXT(as, flags, mask, 0, 0, 0, ray.o, ray.tMin, ray.d, ray.tMax, 0);
 
     RayPayload ret;
-    ret.instanceCustomIndex = payload.instanceCustomIndex;
+    ret.drawInstanceIndex = payload.drawInstanceIndex;
     ret.primitiveID = payload.primitiveID;
     ret.baryCoord = payload.baryCoord;
 
@@ -138,7 +138,7 @@ void importanceSampleBounce(
 
 VisibleSurface evaluateSurface(Ray ray, RayPayload hit)
 {
-    DrawInstance instance = drawInstances.instance[hit.instanceCustomIndex];
+    DrawInstance instance = drawInstances.instance[hit.drawInstanceIndex];
 
     Transforms trfn =
         modelInstanceTransforms.instance[instance.modelInstanceID];
@@ -173,7 +173,7 @@ VisibleSurface evaluateSurface(Ray ray, RayPayload hit)
 
 vec3 debugColor(RayPayload hit, VisibleSurface surface)
 {
-    DrawInstance instance = drawInstances.instance[hit.instanceCustomIndex];
+    DrawInstance instance = drawInstances.instance[hit.drawInstanceIndex];
 
     DebugInputs di;
     di.meshID = instance.meshID;
@@ -237,7 +237,7 @@ void main()
             break;
 
         RayPayload hit = traceClosest(ray);
-        if (hit.instanceCustomIndex == MISS_INDEX)
+        if (hit.drawInstanceIndex == MISS_INDEX)
         {
             if (flagIBL())
             {

--- a/res/shader/rt/scene.rahit
+++ b/res/shader/rt/scene.rahit
@@ -17,7 +17,8 @@ hitAttributeEXT vec2 baryCoord;
 
 void main()
 {
-    DrawInstance instance = drawInstances.instance[gl_InstanceCustomIndexEXT];
+    DrawInstance instance =
+        drawInstances.instance[gl_InstanceCustomIndexEXT + gl_GeometryIndexEXT];
 
     vec2 uv0 = loadUV(instance.meshID, gl_PrimitiveID * 3 + 0);
     vec2 uv1 = loadUV(instance.meshID, gl_PrimitiveID * 3 + 1);

--- a/res/shader/rt/scene.rchit
+++ b/res/shader/rt/scene.rchit
@@ -9,7 +9,7 @@ hitAttributeEXT vec2 baryCoord;
 
 void main()
 {
-    payload.instanceCustomIndex = gl_InstanceCustomIndexEXT;
+    payload.drawInstanceIndex = gl_InstanceCustomIndexEXT + gl_GeometryIndexEXT;
     payload.primitiveID = gl_PrimitiveID;
     payload.baryCoord = baryCoord;
 }

--- a/src/App.cpp
+++ b/src/App.cpp
@@ -1395,7 +1395,8 @@ void App::render(
     if (_referenceRt || _deferredRt || _world->unbuiltBlases())
     {
         auto _s = _profiler->createCpuGpuScope(cb, "BuildTLAS");
-        blasesAdded = _world->buildAccelerationStructures(cb);
+        blasesAdded =
+            _world->buildAccelerationStructures(scopeAlloc.child_scope(), cb);
     }
 
     const LightClusteringOutput lightClusters = _lightClustering->record(

--- a/src/render/MeshletCuller.cpp
+++ b/src/render/MeshletCuller.cpp
@@ -252,6 +252,7 @@ BufferHandle MeshletCuller::recordGenerateList(
 
         for (const ModelInstance &instance : scene.modelInstances)
         {
+            bool modelDrawn = false;
             const Model &model = models[instance.modelID];
             for (const Model::SubModel &subModel : model.subModels)
             {
@@ -271,6 +272,11 @@ BufferHandle MeshletCuller::recordGenerateList(
                         sceneStats->totalTriangleCount += info.indexCount / 3;
                         sceneStats->totalMeshletCount += info.meshletCount;
                         meshletCountUpperBound += info.meshletCount;
+                        if (!modelDrawn)
+                        {
+                            sceneStats->totalModelCount++;
+                            modelDrawn = true;
+                        }
                     }
                 }
             }

--- a/src/scene/World.hpp
+++ b/src/scene/World.hpp
@@ -57,7 +57,8 @@ class World
     void updateBuffers(wheels::ScopedScratch scopeAlloc);
     // Has to be called after updateBuffers(). Returns true if new BLASes were
     // added.
-    bool buildAccelerationStructures(vk::CommandBuffer cb);
+    bool buildAccelerationStructures(
+        wheels::ScopedScratch scopeAlloc, vk::CommandBuffer cb);
     void drawSkybox(vk::CommandBuffer cb) const;
 
     [[nodiscard]] const WorldDSLayouts &dsLayouts() const;

--- a/src/scene/WorldData.cpp
+++ b/src/scene/WorldData.cpp
@@ -653,8 +653,7 @@ bool WorldData::handleDeferredLoading(vk::CommandBuffer cb, Profiler &profiler)
 
 void WorldData::drawDeferredLoadingUi() const
 {
-    if (_deferredLoadingContext.has_value() ||
-        _blases.size() < _meshInfos.size())
+    if (_deferredLoadingContext.has_value() || _blases.size() < _models.size())
     {
         ImGui::SetNextWindowPos(ImVec2{400, 50}, ImGuiCond_Appearing);
         ImGui::Begin(

--- a/src/utils/SceneStats.hpp
+++ b/src/utils/SceneStats.hpp
@@ -9,6 +9,7 @@ struct SceneStats
     uint32_t totalTriangleCount{0};
     uint32_t totalMeshletCount{0};
     uint32_t totalMeshCount{0};
+    uint32_t totalModelCount{0};
     uint32_t totalNodeCount{0};
     uint32_t animatedNodeCount{0};
 };


### PR DESCRIPTION
Should be more optimal for nice content as models are treated as a unit anyway and the submodels share the transform. Of course, content with large holes in model BBs will likely have worse perf now because there is no splitting logic at load time and the TLAS will have more of overlap.