### PR TITLE
Pack vertex data

### DIFF
--- a/src/scene/Mesh.hpp
+++ b/src/scene/Mesh.hpp
@@ -3,6 +3,12 @@
 
 #include "../gfx/Resources.hpp"
 
+constexpr vk::Format sVertexPositionFormat = vk::Format::eR16G16B16A16Sfloat;
+constexpr uint32_t sVertexPositionByteSize = 8;
+constexpr vk::Format sVertexNormalFormat = vk::Format::eA2B10G10R10SnormPack32;
+constexpr vk::Format sVertexTangentFormat = vk::Format::eA2B10G10R10SnormPack32;
+constexpr vk::Format sVertexTexCoord0Format = vk::Format::eR16G16Sfloat;
+
 struct GeometryMetadata
 {
     uint32_t bufferIndex{0xFFFFFFFF};

--- a/src/scene/World.cpp
+++ b/src/scene/World.cpp
@@ -628,9 +628,9 @@ bool World::Impl::buildNextBlas(ScopedScratch scopeAlloc, vk::CommandBuffer cb)
                                           : sizeof(uint32_t));
 
         const vk::AccelerationStructureGeometryTrianglesDataKHR triangles{
-            .vertexFormat = vk::Format::eR32G32B32Sfloat,
+            .vertexFormat = sVertexPositionFormat,
             .vertexData = dataBuffer.deviceAddress + positionsOffset,
-            .vertexStride = 3 * sizeof(float),
+            .vertexStride = sVertexPositionByteSize,
             .maxVertex = info.vertexCount,
             .indexType = metadata.usesShortIndices == 1u
                              ? vk::IndexType::eUint16


### PR DESCRIPTION
Nice reduction from 48B per vertex down to 20B. Not a huge perf improvement for gbuffer though so other parts are probably still hogging bandwidth. Quality is also ok for smallish meshes.

Better quality can be achieved with the same vertex byte count at least by using snorm scaling within the object space AABB for positions.