### PR TITLE
Get rid of gli

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "ext/vma"]
 	path = ext/vma
 	url = https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator.git
-[submodule "ext/gli"]
-	path = ext/gli
-	url = https://github.com/g-truc/gli.git
 [submodule "ext/imgui"]
 	path = ext/imgui
 	url = https://github.com/ocornut/imgui.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,6 @@ target_link_libraries(prosper
     cxxopts
     cgltf
     glfw
-    gli
     glm
     imgui
     ispc_texcomp
@@ -149,7 +148,6 @@ if(PROSPER_USE_PCH)
         [["glm/glm.hpp"]]
         [["glm/gtc/type_ptr.hpp"]]
 
-        # TODO: Get rid of gli (GLM_ENABLE_EXPERIMENTAL redefinition )and put glm/gtx things here
         [["chrono"]]
         [["filesystem"]]
         [["fstream"]]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,7 @@ if(PROSPER_USE_PCH)
 
         [["glm/glm.hpp"]]
         [["glm/gtc/type_ptr.hpp"]]
+        [["glm/gtc/quaternion.hpp"]]
 
         [["chrono"]]
         [["filesystem"]]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,7 @@ target_compile_definitions(prosper
     VULKAN_HPP_NO_SMART_HANDLE
     VULKAN_HPP_NO_SPACESHIP_OPERATOR
     VULKAN_HPP_NO_STRING
+    GLM_FORCE_XYZW_ONLY
     ${LIVEPP_DEFINE}
 
     # Set up absolute path to resources and binaries

--- a/ext/CMakeLists.txt
+++ b/ext/CMakeLists.txt
@@ -89,12 +89,6 @@ add_library(vma INTERFACE)
 # Define as system to suppress warnings
 target_include_directories(vma SYSTEM INTERFACE ${CMAKE_CURRENT_LIST_DIR}/vma/include)
 
-# gli is header only
-add_library(gli INTERFACE)
-
-# Define as system to suppress warnings
-target_include_directories(gli SYSTEM INTERFACE ${CMAKE_CURRENT_LIST_DIR}/gli)
-
 set(WHEELS_BUILD_TESTS OFF CACHE BOOL "Include tests")
 set(WHEELS_BUILD_BENCHES OFF CACHE BOOL "Include benchmarks")
 add_subdirectory(wheels)

--- a/readme.md
+++ b/readme.md
@@ -106,7 +106,6 @@ Vulkan renderer spun off from following https://vulkan-tutorial.com/. Work of [S
 - [cgltf](https://github.com/jkuhlmann/cgltf)
 - [cxxopts](https://github.com/jarro2783/cxxopts)
 - [glfw](https://github.com/glfw/glfw)
-- [gli](https://github.com/g-truc/gli)
 - [glm](https://github.com/g-truc/glm)
 - [imgui](https://github.com/ocornut/imgui)
 - [ISPCTextureCompressor](https://github.com/GameTechDev/ISPCTextureCompressor)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -112,7 +112,8 @@ int main(int argc, char *argv[])
     {
         App::Settings settings = parseCli(argc, argv);
 
-        LinearAllocator scratchBacking{megabytes(16)};
+        // Used by environment map KTX loading so conservative
+        LinearAllocator scratchBacking{megabytes(128)};
         ScopedScratch scopeAlloc{scratchBacking};
 
         const auto &tl = [](const char *stage, std::function<void()> const &fn)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,8 +138,12 @@ int main(int argc, char *argv[])
 
         App app{settings.scene};
         app.init(WHEELS_MOV(scopeAlloc));
+
         app.setInitScratchHighWatermark(
             scratchBacking.allocated_byte_count_high_watermark());
+        // We don't need this memory anymore so let's drop it.
+        scratchBacking.destroy();
+
         printf("run() called after %.2fs\n", t.getSeconds());
         app.run();
     }

--- a/src/scene/Texture.hpp
+++ b/src/scene/Texture.hpp
@@ -3,15 +3,11 @@
 
 #include "../gfx/Fwd.hpp"
 #include "../gfx/Resources.hpp"
+#include "../utils/Fwd.hpp"
 
 #include <wheels/allocators/scoped_scratch.hpp>
 
 #include <filesystem>
-
-namespace gli
-{
-class texture_cube;
-}
 
 namespace tinygltf
 {
@@ -79,7 +75,7 @@ class TextureCubemap : public Texture
 
   private:
     void copyPixels(
-        wheels::ScopedScratch scopeAlloc, const gli::texture_cube &cube,
+        wheels::ScopedScratch scopeAlloc, const Ktx &cube,
         const vk::ImageSubresourceRange &subresourceRange) const;
 
     vk::Sampler _sampler;

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -4,6 +4,7 @@ set(PROSPER_UTILS_INCLUDES
     ${CMAKE_CURRENT_LIST_DIR}/Fwd.hpp
     ${CMAKE_CURRENT_LIST_DIR}/Hashes.hpp
     ${CMAKE_CURRENT_LIST_DIR}/InputHandler.hpp
+    ${CMAKE_CURRENT_LIST_DIR}/Ktx.hpp
     ${CMAKE_CURRENT_LIST_DIR}/Profiler.hpp
     ${CMAKE_CURRENT_LIST_DIR}/SceneStats.hpp
     ${CMAKE_CURRENT_LIST_DIR}/Timer.hpp
@@ -15,6 +16,7 @@ set(PROSPER_UTILS_INCLUDES
 set(PROSPER_UTILS_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/Dds.cpp
     ${CMAKE_CURRENT_LIST_DIR}/InputHandler.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/Ktx.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Profiler.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Timer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/Utils.cpp

--- a/src/utils/Fwd.hpp
+++ b/src/utils/Fwd.hpp
@@ -9,6 +9,9 @@ class InputHandler;
 struct CursorState;
 struct MouseGesture;
 
+// Ktx.hpp
+struct Ktx;
+
 // Profiler.hpp
 class CpuFrameProfiler;
 class GpuFrameProfiler;

--- a/src/utils/Ktx.cpp
+++ b/src/utils/Ktx.cpp
@@ -1,0 +1,162 @@
+#include "Ktx.hpp"
+
+#include "Utils.hpp"
+#include <cstdint>
+#include <fstream>
+#include <wheels/assert.hpp>
+#include <wheels/containers/static_array.hpp>
+
+using namespace wheels;
+
+// Based on the official specs
+// https://registry.khronos.org/KTX/specs/1.0/ktxspec.v1.html
+// https://registry.khronos.org/KTX/specs/2.0/ktxspec.v2.html
+
+namespace
+{
+
+// «KTX 20»\r\n\x1A\n
+const StaticArray<uint8_t, 12> sFileIdentifier20{
+    {0xAB, 0x4B, 0x54, 0x58, 0x20, 0x32, 0x30, 0xBB, 0x0D, 0x0A, 0x1A, 0x0A}};
+static_assert(sizeof(sFileIdentifier20) == 12 * sizeof(uint8_t));
+// «KTX 11»\r\n\x1A\n
+const StaticArray<uint8_t, 12> sFileIdentifier10{
+    {0xAB, 0x4B, 0x54, 0x58, 0x20, 0x31, 0x31, 0xBB, 0x0D, 0x0A, 0x1A, 0x0A}};
+static_assert(sizeof(sFileIdentifier10) == sizeof(sFileIdentifier20));
+
+struct Ktx10Header
+{
+    uint32_t endianness{0};
+    uint32_t glType{0};
+    uint32_t glTypeSize{0};
+    uint32_t glFormat{0};
+    uint32_t glInternalFormat{0};
+    uint32_t glBaseInternalFormat{0};
+    uint32_t pixelWidth{0};
+    uint32_t pixelHeight{0};
+    uint32_t pixelDepth{0};
+    uint32_t numberOfArrayElements{0};
+    uint32_t numberOfFaces{0};
+    uint32_t numberOfMipmapLevels{0};
+    uint32_t bytesOfKeyValueData{0};
+};
+
+} // namespace
+
+Ktx readKtx(Allocator &alloc, const std::filesystem::path &path)
+{
+    std::ifstream inFile{path, std::ios_base::binary};
+
+    StaticArray<uint8_t, 12> identifier;
+    static_assert(sizeof(identifier) == sizeof(sFileIdentifier20));
+    readRawSpan(inFile, identifier.mut_span());
+
+    if (memcmp(
+            identifier.data(), sFileIdentifier20.data(),
+            identifier.size() * sizeof(uint8_t)) == 0)
+        throw std::runtime_error("KTX 2.0 is not supported");
+    WHEELS_ASSERT(
+        memcmp(
+            identifier.data(), sFileIdentifier10.data(),
+            identifier.size() * sizeof(uint8_t)) == 0 &&
+        "File doesn't appear to be a KTX");
+
+    Ktx10Header header;
+    readRaw(inFile, header);
+
+    WHEELS_ASSERT(
+        header.endianness == 0x04030201 &&
+        "KTX and program endianness don't match");
+
+    // GL_HALF_FLOAT, GL_RGBA(16F)
+    WHEELS_ASSERT(
+        header.glType == 0x140b && header.glFormat == 0x1908 &&
+        header.glInternalFormat == 0x881a &&
+        header.glBaseInternalFormat == header.glFormat &&
+        "Only RGBA16F is supported");
+    const vk::Format format = vk::Format::eR16G16B16A16Sfloat;
+    const uint32_t blockWidth = 1;
+    const uint32_t blockHeight = 1;
+    const uint32_t blockDepth = 1;
+    const uint32_t blockByteCount = 8;
+
+    // Ignore key value data
+    inFile.seekg(header.bytesOfKeyValueData, std::ios_base::cur);
+
+    Ktx ret{
+        .width = header.pixelWidth,
+        .height = std::max(header.pixelHeight, 1u),
+        .depth = std::max(header.pixelDepth, 1u),
+        .format = format,
+        .arrayLayerCount = std::max(header.numberOfArrayElements, 1u),
+        .faceCount = std::max(header.numberOfFaces, 1u),
+        .mipLevelCount = std::max(1u, header.numberOfMipmapLevels),
+        .data = Array<uint8_t>{alloc},
+        .levelByteOffsets = Array<uint32_t>{alloc},
+    };
+    WHEELS_ASSERT(ret.width > 0);
+
+    const bool isCubemap =
+        header.numberOfArrayElements == 1 || header.numberOfFaces == 6;
+
+    // Let's reserve conservatively to avoid reallocations. Each mip his half of
+    // the previous one so 3x the size of mip0 layers and faces is more than
+    // enough even for block compressed and weirdly rounded data.
+    const uint32_t conservativeByteCount =
+        3 * ret.arrayLayerCount * ret.faceCount *
+        roundedUpQuotient(ret.width, blockWidth) *
+        roundedUpQuotient(ret.height, blockHeight) *
+        roundedUpQuotient(ret.depth, blockDepth) * blockByteCount;
+    ret.data.reserve(conservativeByteCount);
+    ret.levelByteOffsets.reserve(
+        asserted_cast<size_t>(ret.mipLevelCount) *
+        asserted_cast<size_t>(ret.arrayLayerCount) *
+        asserted_cast<size_t>(ret.faceCount));
+
+    // Levels are stored mips[layers[faces[z_slices[rows[pixels/blocks[]]]]]]
+    for (uint32_t iMip = 0; iMip < ret.mipLevelCount; ++iMip)
+    {
+        uint32_t imageSize = 0;
+        readRaw(inFile, imageSize);
+
+        uint32_t cubePadding = 0;
+        if (isCubemap)
+        {
+            cubePadding = imageSize % 4;
+            // Cubemap imageSize is the size of one face
+            imageSize *= 6;
+        }
+        WHEELS_ASSERT(
+            cubePadding == 0 && "Parsing expects tightly packed faces");
+
+        const uint32_t mipStartOffset =
+            asserted_cast<uint32_t>(ret.data.size());
+        ret.data.resize(ret.data.size() + imageSize);
+        // We checked that cubes have no padding so we can just read the
+        // whole size in one go
+        readRawSpan(inFile, Span{ret.data.data() + mipStartOffset, imageSize});
+
+        // Figure out layer/face offsets separately
+        uint32_t readMipBytes = 0;
+        const uint32_t faceByteCount = imageSize / ret.faceCount;
+        for (uint32_t iLayer = 0; iLayer < ret.arrayLayerCount; ++iLayer)
+        {
+            for (uint32_t iFace = 0; iFace < ret.faceCount; ++iFace)
+            {
+                const uint32_t faceStartOffset = mipStartOffset + readMipBytes;
+                ret.levelByteOffsets.push_back(faceStartOffset);
+
+                readMipBytes += faceByteCount;
+                WHEELS_ASSERT(readMipBytes <= imageSize);
+
+                // We already checked that there is no cube padding
+            }
+        }
+        WHEELS_ASSERT(readMipBytes == imageSize);
+
+        const uint32_t mipPadding = readMipBytes % 4;
+        inFile.seekg(mipPadding, std::ios_base::cur);
+    }
+
+    return ret;
+}

--- a/src/utils/Ktx.hpp
+++ b/src/utils/Ktx.hpp
@@ -1,0 +1,29 @@
+#ifndef PROSPER_UTILS_KTX_HPP
+#define PROSPER_UTILS_KTX_HPP
+
+#include <cstdint>
+#include <filesystem>
+#include <vulkan/vulkan.hpp>
+
+#include <wheels/allocators/allocator.hpp>
+#include <wheels/containers/array.hpp>
+
+// https://registry.khronos.org/KTX/specs/2.0/ktxspec.v2.html
+struct Ktx
+{
+    uint32_t width{0};
+    uint32_t height{0};
+    uint32_t depth{0};
+    vk::Format format{vk::Format::eUndefined};
+    uint32_t arrayLayerCount{0};
+    uint32_t faceCount{0};
+    uint32_t mipLevelCount{0};
+    wheels::Array<uint8_t> data;
+    // Offsets for individual faces in the texture. Indexed using
+    // (iMip * arrayLayerCount * faceCount) + (iLayer * faceCount) + iFace
+    wheels::Array<uint32_t> levelByteOffsets;
+};
+
+Ktx readKtx(wheels::Allocator &alloc, const std::filesystem::path &path);
+
+#endif // PROSPER_UTILS_KTX_HPP


### PR DESCRIPTION
Gli was only used for environment map parsing and it prevented having some GLM flags in PCH