### PR TITLE
Add profiler macros and separate most cpu/gpu scopes

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -232,7 +232,7 @@ void App::run()
             ScopedScratch scopeAlloc{scopeBackingAlloc};
 
             {
-                const auto _s = _profiler->createCpuScope("Window::startFrame");
+                PROFILER_CPU_SCOPE(_profiler, "Window::startFrame");
                 gWindow.startFrame();
             }
 
@@ -328,7 +328,7 @@ void App::recreateSwapchainAndRelated(ScopedScratch scopeAlloc)
 
 void App::recompileShaders(ScopedScratch scopeAlloc)
 {
-    const auto _s = _profiler->createCpuScope("App::recompileShaders");
+    PROFILER_CPU_SCOPE(_profiler, "App::recompileShaders");
 
     if (!_recompileShaders)
     {
@@ -447,7 +447,7 @@ void App::recompileShaders(ScopedScratch scopeAlloc)
 
 void App::handleMouseGestures()
 {
-    const auto _s = _profiler->createCpuScope("App::handleMouseGestures");
+    PROFILER_CPU_SCOPE(_profiler, "App::handleMouseGestures");
 
     // Gestures adapted from Max Liani
     // https://maxliani.wordpress.com/2021/06/08/offline-to-realtime-camera-manipulation/
@@ -698,7 +698,7 @@ void App::drawFrame(ScopedScratch scopeAlloc, uint32_t scopeHighWatermark)
     _cam->updateBuffer(_debugFrustum);
 
     {
-        auto _s = _profiler->createCpuScope("World::updateBuffers");
+        PROFILER_CPU_SCOPE(_profiler, "World::updateBuffers");
         _world->updateBuffers(scopeAlloc.child_scope());
     }
 
@@ -723,7 +723,7 @@ void App::drawFrame(ScopedScratch scopeAlloc, uint32_t scopeHighWatermark)
         },
         uiChanges);
 
-    _newSceneDataLoaded = _world->handleDeferredLoading(cb, *_profiler);
+    _newSceneDataLoaded = _world->handleDeferredLoading(cb, _profiler.get());
 
     _profiler->endGpuFrame(cb);
 
@@ -825,7 +825,7 @@ App::UiChanges App::drawUi(
     const Array<Profiler::ScopeData> &profilerDatas,
     uint32_t scopeHighWatermark)
 {
-    const auto _s = _profiler->createCpuScope("App::drawUi");
+    PROFILER_CPU_SCOPE(_profiler, "App::drawUi");
 
     UiChanges ret;
     // Actual scene change happens after the frame so let's initialize here with
@@ -1348,7 +1348,7 @@ void App::render(
     bool blasesAdded = false;
     if (_referenceRt || _deferredRt || _world->unbuiltBlases())
     {
-        auto _s = _profiler->createCpuGpuScope(cb, "BuildTLAS");
+        PROFILER_CPU_GPU_SCOPE(_profiler, cb, "BuildTLAS");
         blasesAdded =
             _world->buildAccelerationStructures(scopeAlloc.child_scope(), cb);
     }
@@ -1661,8 +1661,7 @@ ImageHandle App::blitColorToFinalComposite(
 
     // This scope has a barrier, but that's intentional as it should contain
     // both the clear and the blit
-    const auto _s =
-        _profiler->createCpuGpuScope(cb, "blitColorToFinalComposite");
+    PROFILER_CPU_GPU_SCOPE(_profiler, cb, "blitColorToFinalComposite");
 
     const vk::ClearColorValue clearColor{0.f, 0.f, 0.f, 0.f};
     const vk::ImageSubresourceRange subresourceRange{
@@ -1794,7 +1793,7 @@ void App::blitFinalComposite(
     });
 
     {
-        const auto _s = _profiler->createCpuGpuScope(cb, "BlitFinalComposite");
+        PROFILER_CPU_GPU_SCOPE(_profiler, cb, "BlitFinalComposite");
 
         const vk::ImageSubresourceLayers layers{
             .aspectMask = vk::ImageAspectFlagBits::eColor,

--- a/src/render/DebugRenderer.cpp
+++ b/src/render/DebugRenderer.cpp
@@ -108,7 +108,8 @@ void DebugRenderer::record(
     Profiler *profiler) const
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, "Debug");
 
     {
         const vk::Rect2D renderArea = getRect2D(inOutTargets.color);
@@ -140,7 +141,7 @@ void DebugRenderer::record(
                 .storeOp = vk::AttachmentStoreOp::eStore,
             }};
 
-        const auto _s = profiler->createCpuGpuScope(cb, "Debug", true);
+        PROFILER_GPU_SCOPE_WITH_STATS(profiler, cb, "Debug");
 
         cb.beginRendering(vk::RenderingInfo{
             .renderArea = renderArea,

--- a/src/render/DeferredShading.cpp
+++ b/src/render/DeferredShading.cpp
@@ -125,7 +125,8 @@ DeferredShading::Output DeferredShading::record(
     bool applyIbl, DrawType drawType, Profiler *profiler)
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, "DeferredShading");
 
     Output ret;
     {
@@ -187,7 +188,7 @@ DeferredShading::Output DeferredShading::record(
                 }},
             });
 
-        const auto _s = profiler->createCpuGpuScope(cb, "DeferredShading");
+        PROFILER_GPU_SCOPE(profiler, cb, "DeferredShading");
 
         const PCBlock pcBlock{
             .drawType = static_cast<uint32_t>(drawType),

--- a/src/render/ForwardRenderer.cpp
+++ b/src/render/ForwardRenderer.cpp
@@ -392,7 +392,8 @@ void ForwardRenderer::record(
 {
     WHEELS_ASSERT(meshletCuller != nullptr);
     WHEELS_ASSERT(sceneStats != nullptr);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, debugName);
 
     const vk::Rect2D renderArea = getRect2D(inOutTargets.illumination);
 
@@ -439,7 +440,7 @@ void ForwardRenderer::record(
     const Attachments attachments =
         createAttachments(inOutTargets, options.transparents);
 
-    const auto _s = profiler->createCpuGpuScope(cb, debugName, true);
+    PROFILER_GPU_SCOPE_WITH_STATS(profiler, cb, debugName);
 
     cb.beginRendering(vk::RenderingInfo{
         .renderArea = renderArea,

--- a/src/render/GBufferRenderer.cpp
+++ b/src/render/GBufferRenderer.cpp
@@ -114,7 +114,8 @@ GBufferRendererOutput GBufferRenderer::record(
     WHEELS_ASSERT(_initialized);
     WHEELS_ASSERT(meshletCuller != nullptr);
     WHEELS_ASSERT(sceneStats != nullptr);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, "GBuffer");
 
     GBufferRendererOutput ret;
     {
@@ -214,7 +215,7 @@ GBufferRendererOutput GBufferRenderer::record(
                 },
         };
 
-        const auto _s = profiler->createCpuGpuScope(cb, "GBuffer", true);
+        PROFILER_GPU_SCOPE_WITH_STATS(profiler, cb, "GBuffer");
 
         cb.beginRendering(vk::RenderingInfo{
             .renderArea = renderArea,

--- a/src/render/ImGuiRenderer.cpp
+++ b/src/render/ImGuiRenderer.cpp
@@ -130,8 +130,8 @@ void ImGuiRenderer::init(const SwapchainConfig &swapConfig)
 void ImGuiRenderer::startFrame(Profiler *profiler)
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
-    const auto _s = profiler->createCpuScope("ImGui::startFrame");
+
+    PROFILER_CPU_SCOPE(profiler, "ImGui::startFrame");
 
     ImGui_ImplVulkan_NewFrame();
     ImGui_ImplGlfw_NewFrame();
@@ -149,19 +149,20 @@ void ImGuiRenderer::endFrame(
     Profiler *profiler) const
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
 
     {
-        const auto _s = profiler->createCpuScope("ImGui::render");
+        PROFILER_CPU_SCOPE(profiler, "ImGui::render");
         ImGui::Render();
     }
     ImDrawData *drawData = ImGui::GetDrawData();
 
     {
+        PROFILER_CPU_SCOPE(profiler, "ImGui::draw");
+
         gRenderResources.images->transition(
             cb, inOutColor, ImageState::ColorAttachmentReadWrite);
 
-        const auto _s = profiler->createCpuGpuScope(cb, "ImGui::draw", true);
+        PROFILER_GPU_SCOPE_WITH_STATS(profiler, cb, "ImGui::draw");
 
         const vk::RenderingAttachmentInfo attachment{
             .imageView = gRenderResources.images->resource(inOutColor).view,

--- a/src/render/LightClustering.cpp
+++ b/src/render/LightClustering.cpp
@@ -171,6 +171,8 @@ LightClusteringOutput LightClustering::record(
 {
     WHEELS_ASSERT(_initialized);
 
+    PROFILER_CPU_SCOPE(profiler, "LightClustering");
+
     LightClusteringOutput ret;
     {
         ret = createOutputs(renderExtent);
@@ -203,7 +205,7 @@ LightClusteringOutput LightClustering::record(
                 }},
             });
 
-        const auto _s = profiler->createCpuGpuScope(cb, "LightClustering");
+        PROFILER_GPU_SCOPE(profiler, cb, "LightClustering");
 
         { // Reset count
             const TexelBuffer &indicesCount =

--- a/src/render/MeshletCuller.cpp
+++ b/src/render/MeshletCuller.cpp
@@ -210,7 +210,8 @@ MeshletCullerOutput MeshletCuller::record(
     String scopeName{scopeAlloc};
     scopeName.extend(debugPrefix);
     scopeName.extend("DrawList");
-    const auto _s = profiler->createCpuGpuScope(cb, scopeName.c_str());
+
+    PROFILER_CPU_GPU_SCOPE(profiler, cb, scopeName.c_str());
 
     const BufferHandle initialList = recordGenerateList(
         scopeAlloc.child_scope(), cb, mode, world, nextFrame, debugPrefix,

--- a/src/render/RtReference.cpp
+++ b/src/render/RtReference.cpp
@@ -174,6 +174,8 @@ RtReference::Output RtReference::record(
 {
     WHEELS_ASSERT(_initialized);
 
+    PROFILER_CPU_SCOPE(profiler, "RtReference");
+
     _frameIndex = ++_frameIndex % sFramePeriod;
 
     Output ret;
@@ -236,7 +238,7 @@ RtReference::Output RtReference::record(
                 }},
             });
 
-        const auto _s = profiler->createCpuGpuScope(cb, "RtReference");
+        PROFILER_GPU_SCOPE(profiler, cb, "RtReference");
 
         cb.bindPipeline(vk::PipelineBindPoint::eRayTracingKHR, _pipeline);
 

--- a/src/render/SkyboxRenderer.cpp
+++ b/src/render/SkyboxRenderer.cpp
@@ -85,7 +85,8 @@ void SkyboxRenderer::record(
     Profiler *profiler) const
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, "Skybox");
 
     {
         const vk::Rect2D renderArea = getRect2D(inOutTargets.illumination);
@@ -133,7 +134,7 @@ void SkyboxRenderer::record(
                 },
         };
 
-        const auto _s = profiler->createCpuGpuScope(cb, "Skybox", true);
+        PROFILER_GPU_SCOPE_WITH_STATS(profiler, cb, "Skybox");
 
         cb.beginRendering(vk::RenderingInfo{
             .renderArea = renderArea,

--- a/src/render/TemporalAntiAliasing.cpp
+++ b/src/render/TemporalAntiAliasing.cpp
@@ -143,7 +143,8 @@ TemporalAntiAliasing::Output TemporalAntiAliasing::record(
     const Input &input, const uint32_t nextFrame, Profiler *profiler)
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, "TemporalAntiAliasing");
 
     Output ret;
     {
@@ -229,7 +230,7 @@ TemporalAntiAliasing::Output TemporalAntiAliasing::record(
                 }},
             });
 
-        const auto _s = profiler->createCpuGpuScope(cb, "TemporalAntiAliasing");
+        PROFILER_GPU_SCOPE(profiler, cb, "TemporalAntiAliasing");
 
         const uvec3 extent = uvec3{renderExtent.width, renderExtent.height, 1u};
 

--- a/src/render/TextureDebug.cpp
+++ b/src/render/TextureDebug.cpp
@@ -249,7 +249,8 @@ ImageHandle TextureDebug::record(
     Profiler *profiler)
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, "TextureDebug");
 
     ImageHandle ret;
     {
@@ -350,7 +351,7 @@ ImageHandle TextureDebug::record(
                         },
                 });
 
-            const auto _s = profiler->createCpuGpuScope(cb, "TextureDebug");
+            PROFILER_GPU_SCOPE(profiler, cb, "TextureDebug");
 
             const vk::Extent3D inExtent =
                 gRenderResources.images->resource(inColor).extent;

--- a/src/render/TextureReadback.cpp
+++ b/src/render/TextureReadback.cpp
@@ -80,7 +80,8 @@ void TextureReadback::record(
     WHEELS_ASSERT(_initialized);
     WHEELS_ASSERT(
         _framesUntilReady == -1 && "Readback already queued and unread");
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, "TextureReadback");
 
     {
         const BufferHandle deviceReadback = gRenderResources.buffers->create(
@@ -125,7 +126,7 @@ void TextureReadback::record(
                     },
             });
 
-        const auto _s = profiler->createCpuGpuScope(cb, "TextureReadback");
+        PROFILER_GPU_SCOPE(profiler, cb, "TextureReadback");
 
         const vk::Extent3D inRes =
             gRenderResources.images->resource(inTexture).extent;

--- a/src/render/ToneMap.cpp
+++ b/src/render/ToneMap.cpp
@@ -72,7 +72,8 @@ ToneMap::Output ToneMap::record(
     const uint32_t nextFrame, Profiler *profiler)
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, "ToneMap");
 
     Output ret;
     {
@@ -121,7 +122,7 @@ ToneMap::Output ToneMap::record(
                 }},
             });
 
-        const auto _s = profiler->createCpuGpuScope(cb, "ToneMap");
+        PROFILER_GPU_SCOPE(profiler, cb, "ToneMap");
 
         const uvec3 extent = uvec3{renderExtent.width, renderExtent.height, 1u};
 

--- a/src/render/dof/DepthOfField.cpp
+++ b/src/render/dof/DepthOfField.cpp
@@ -48,9 +48,10 @@ DepthOfField::Output DepthOfField::record(
 {
     WHEELS_ASSERT(_initialized);
 
+    PROFILER_CPU_GPU_SCOPE(profiler, cb, "DepthOfField");
+
     Output ret;
     {
-        const auto _s = profiler->createCpuGpuScope(cb, "DepthOfField");
 
         const DepthOfFieldSetup::Output setupOutput = _setupPass.record(
             scopeAlloc.child_scope(), cb, cam, input, nextFrame, profiler);

--- a/src/render/dof/DepthOfFieldCombine.cpp
+++ b/src/render/dof/DepthOfFieldCombine.cpp
@@ -53,7 +53,8 @@ DepthOfFieldCombine::Output DepthOfFieldCombine::record(
     const uint32_t nextFrame, Profiler *profiler)
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, "  Combine");
 
     Output ret;
     {
@@ -110,7 +111,7 @@ DepthOfFieldCombine::Output DepthOfFieldCombine::record(
                 }},
             });
 
-        const auto _s = profiler->createCpuGpuScope(cb, "  Combine");
+        PROFILER_GPU_SCOPE(profiler, cb, "  Combine");
 
         const uvec3 extent = uvec3{renderExtent.width, renderExtent.height, 1u};
         const vk::DescriptorSet storageSet = _computePass.storageSet(nextFrame);

--- a/src/render/dof/DepthOfFieldDilate.cpp
+++ b/src/render/dof/DepthOfFieldDilate.cpp
@@ -61,7 +61,8 @@ DepthOfFieldDilate::Output DepthOfFieldDilate::record(
     const Camera &cam, const uint32_t nextFrame, Profiler *profiler)
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, "  Dilate");
 
     Output ret;
     {
@@ -105,7 +106,7 @@ DepthOfFieldDilate::Output DepthOfFieldDilate::record(
                 }},
             });
 
-        const auto _s = profiler->createCpuGpuScope(cb, "  Dilate");
+        PROFILER_GPU_SCOPE(profiler, cb, "  Dilate");
 
         const CameraParameters &camParams = cam.parameters();
         const float maxBgCoCInUnits =

--- a/src/render/dof/DepthOfFieldFilter.cpp
+++ b/src/render/dof/DepthOfFieldFilter.cpp
@@ -54,7 +54,8 @@ DepthOfFieldFilter::Output DepthOfFieldFilter::record(
     const DebugNames &debugNames, Profiler *profiler)
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, debugNames.scope);
 
     const Image &inRes =
         gRenderResources.images->resource(inIlluminationWeight);
@@ -100,7 +101,7 @@ DepthOfFieldFilter::Output DepthOfFieldFilter::record(
             }},
         });
 
-    const auto _s = profiler->createCpuGpuScope(cb, debugNames.scope);
+    PROFILER_GPU_SCOPE(profiler, cb, debugNames.scope);
 
     const vk::DescriptorSet descriptorSet = _computePass.storageSet(nextFrame);
 

--- a/src/render/dof/DepthOfFieldFlatten.cpp
+++ b/src/render/dof/DepthOfFieldFlatten.cpp
@@ -56,7 +56,8 @@ DepthOfFieldFlatten::Output DepthOfFieldFlatten::record(
     Profiler *profiler)
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, "  Flatten");
 
     Output ret;
     {
@@ -101,7 +102,7 @@ DepthOfFieldFlatten::Output DepthOfFieldFlatten::record(
                 }},
             });
 
-        const auto _s = profiler->createCpuGpuScope(cb, "  Flatten");
+        PROFILER_GPU_SCOPE(profiler, cb, "  Flatten");
 
         const uvec3 extent = uvec3{inputExtent.width, inputExtent.height, 1u};
         const vk::DescriptorSet storageSet = _computePass.storageSet(nextFrame);

--- a/src/render/dof/DepthOfFieldGather.cpp
+++ b/src/render/dof/DepthOfFieldGather.cpp
@@ -79,8 +79,12 @@ DepthOfFieldGather::Output DepthOfFieldGather::record(
     GatherType gatherType, const uint32_t nextFrame, Profiler *profiler)
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
     WHEELS_ASSERT(gatherType < GatherType_Count);
+
+    const char *const debugString = gatherType == GatherType_Background
+                                        ? "  GatherBackground"
+                                        : "  GatherForeground";
+    PROFILER_CPU_SCOPE(profiler, debugString);
 
     ComputePass *computePass = gatherType == GatherType_Foreground
                                    ? &_foregroundPass
@@ -152,9 +156,7 @@ DepthOfFieldGather::Output DepthOfFieldGather::record(
                 }},
             });
 
-        const auto _s = profiler->createCpuGpuScope(
-            cb, gatherType == GatherType_Background ? "  GatherBackground"
-                                                    : "  GatherForeground");
+        PROFILER_GPU_SCOPE(profiler, cb, debugString);
 
         const PCBlock pcBlock{
             .halfResolution =

--- a/src/render/dof/DepthOfFieldReduce.cpp
+++ b/src/render/dof/DepthOfFieldReduce.cpp
@@ -99,7 +99,8 @@ void DepthOfFieldReduce::record(
     Profiler *profiler)
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, "  Reduce");
 
     const Image &inOutRes =
         gRenderResources.images->resource(inOutIlluminationMips);
@@ -173,7 +174,7 @@ void DepthOfFieldReduce::record(
         _counterNotCleared = false;
     }
 
-    const auto _s = profiler->createCpuGpuScope(cb, "  Reduce");
+    PROFILER_GPU_SCOPE(profiler, cb, "  Reduce");
 
     const vk::DescriptorSet descriptorSet = _computePass.storageSet(nextFrame);
 

--- a/src/render/dof/DepthOfFieldSetup.cpp
+++ b/src/render/dof/DepthOfFieldSetup.cpp
@@ -82,7 +82,8 @@ DepthOfFieldSetup::Output DepthOfFieldSetup::record(
     const Input &input, const uint32_t nextFrame, Profiler *profiler)
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, "  Setup");
 
     Output ret;
     {
@@ -158,7 +159,7 @@ DepthOfFieldSetup::Output DepthOfFieldSetup::record(
                 }},
             });
 
-        const auto _s = profiler->createCpuGpuScope(cb, "  Setup");
+        PROFILER_GPU_SCOPE(profiler, cb, "  Setup");
 
         StaticArray<vk::DescriptorSet, BindingSetCount> descriptorSets{
             VK_NULL_HANDLE};

--- a/src/render/rtdi/RtDiInitialReservoirs.cpp
+++ b/src/render/rtdi/RtDiInitialReservoirs.cpp
@@ -102,7 +102,8 @@ RtDiInitialReservoirs::Output RtDiInitialReservoirs::record(
     const uint32_t nextFrame, Profiler *profiler)
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, "  InitialReservoirs");
 
     _frameIndex = ++_frameIndex % sFramePeriod;
 
@@ -161,7 +162,7 @@ RtDiInitialReservoirs::Output RtDiInitialReservoirs::record(
                 }},
             });
 
-        const auto _s = profiler->createCpuGpuScope(cb, "  InitialReservoirs");
+        PROFILER_GPU_SCOPE(profiler, cb, "  InitialReservoirs");
 
         const WorldDescriptorSets &worldDSes = world.descriptorSets();
         const WorldByteOffsets &worldByteOffsets = world.byteOffsets();

--- a/src/render/rtdi/RtDiSpatialReuse.cpp
+++ b/src/render/rtdi/RtDiSpatialReuse.cpp
@@ -102,7 +102,8 @@ RtDiSpatialReuse::Output RtDiSpatialReuse::record(
     Profiler *profiler)
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, "  SpatialReuse");
 
     _frameIndex = ++_frameIndex % sFramePeriod;
 
@@ -172,7 +173,7 @@ RtDiSpatialReuse::Output RtDiSpatialReuse::record(
                 }},
             });
 
-        const auto _s = profiler->createCpuGpuScope(cb, "  SpatialReuse");
+        PROFILER_GPU_SCOPE(profiler, cb, "  SpatialReuse");
 
         const WorldDescriptorSets &worldDSes = world.descriptorSets();
         const WorldByteOffsets &worldByteOffsets = world.byteOffsets();

--- a/src/render/rtdi/RtDiTrace.cpp
+++ b/src/render/rtdi/RtDiTrace.cpp
@@ -146,7 +146,8 @@ RtDiTrace::Output RtDiTrace::record(
     DrawType drawType, uint32_t nextFrame, Profiler *profiler)
 {
     WHEELS_ASSERT(_initialized);
-    WHEELS_ASSERT(profiler != nullptr);
+
+    PROFILER_CPU_SCOPE(profiler, "  Trace");
 
     _frameIndex = ++_frameIndex % sFramePeriod;
 
@@ -209,7 +210,7 @@ RtDiTrace::Output RtDiTrace::record(
                 }},
             });
 
-        const auto _s = profiler->createCpuGpuScope(cb, "  Trace");
+        PROFILER_GPU_SCOPE(profiler, cb, "  Trace");
 
         cb.bindPipeline(vk::PipelineBindPoint::eRayTracingKHR, _pipeline);
 

--- a/src/render/rtdi/RtDirectIllumination.cpp
+++ b/src/render/rtdi/RtDirectIllumination.cpp
@@ -71,9 +71,10 @@ RtDirectIllumination::Output RtDirectIllumination::record(
 {
     WHEELS_ASSERT(_initialized);
 
+    PROFILER_CPU_GPU_SCOPE(profiler, cb, "RtDirectIllumination");
+
     Output ret;
     {
-        const auto _s = profiler->createCpuGpuScope(cb, "RtDirectIllumination");
 
         const RtDiInitialReservoirs::Output initialReservoirsOutput =
             _initialReservoirs.record(

--- a/src/scene/World.cpp
+++ b/src/scene/World.cpp
@@ -341,9 +341,7 @@ AccelerationStructure &World::Impl::currentTLAS()
 
 void World::Impl::updateAnimations(float timeS, Profiler *profiler)
 {
-    WHEELS_ASSERT(profiler != nullptr);
-
-    auto _s = profiler->createCpuScope("World::updateAnimations");
+    PROFILER_CPU_SCOPE(profiler, "World::updateAnimations");
 
     for (Animation<vec3> &animation : _data._animations._vec3)
         animation.update(timeS);
@@ -355,11 +353,10 @@ void World::Impl::updateScene(
     ScopedScratch scopeAlloc, CameraTransform *cameraTransform,
     SceneStats *sceneStats, Profiler *profiler)
 {
-    WHEELS_ASSERT(profiler != nullptr);
     WHEELS_ASSERT(cameraTransform != nullptr);
     WHEELS_ASSERT(sceneStats != nullptr);
 
-    auto _s = profiler->createCpuScope("World::updateScene");
+    PROFILER_CPU_SCOPE(profiler, "World::updateScene");
 
     Scene &scene = currentScene();
 
@@ -972,7 +969,7 @@ void World::endFrame()
     _impl->endFrame();
 }
 
-bool World::handleDeferredLoading(vk::CommandBuffer cb, Profiler &profiler)
+bool World::handleDeferredLoading(vk::CommandBuffer cb, Profiler *profiler)
 {
     WHEELS_ASSERT(_initialized);
     return _impl->_data.handleDeferredLoading(cb, profiler);

--- a/src/scene/World.hpp
+++ b/src/scene/World.hpp
@@ -30,7 +30,7 @@ class World
     void endFrame();
 
     // Returns true if the visible scene was changed.
-    bool handleDeferredLoading(vk::CommandBuffer cb, Profiler &profiler);
+    bool handleDeferredLoading(vk::CommandBuffer cb, Profiler *profiler);
     bool unbuiltBlases() const;
 
     void drawDeferredLoadingUi() const;

--- a/src/scene/WorldData.cpp
+++ b/src/scene/WorldData.cpp
@@ -568,7 +568,7 @@ void WorldData::uploadMaterialDatas(uint32_t nextFrame)
         _deferredLoadingContext->materialsGeneration;
 }
 
-bool WorldData::handleDeferredLoading(vk::CommandBuffer cb, Profiler &profiler)
+bool WorldData::handleDeferredLoading(vk::CommandBuffer cb, Profiler *profiler)
 {
     if (!_deferredLoadingContext.has_value())
         return false;
@@ -598,7 +598,7 @@ bool WorldData::handleDeferredLoading(vk::CommandBuffer cb, Profiler &profiler)
     }
 
     // No gpu as timestamps are flaky for this work
-    const auto _s = profiler.createCpuScope("DeferredLoading");
+    PROFILER_CPU_SCOPE(profiler, "DeferredLoading");
 
     if (ctx.loadedImageCount == 0)
         _materialStreamingTimer.reset();

--- a/src/scene/WorldData.hpp
+++ b/src/scene/WorldData.hpp
@@ -49,7 +49,7 @@ class WorldData
     void uploadMeshDatas(wheels::ScopedScratch scopeAlloc, uint32_t nextFrame);
     void uploadMaterialDatas(uint32_t nextFrame);
     // Returns true if the visible scene was changed.
-    bool handleDeferredLoading(vk::CommandBuffer cb, Profiler &profiler);
+    bool handleDeferredLoading(vk::CommandBuffer cb, Profiler *profiler);
 
     void drawDeferredLoadingUi() const;
 

--- a/src/utils/Profiler.hpp
+++ b/src/utils/Profiler.hpp
@@ -6,6 +6,7 @@
 #include "../gfx/Resources.hpp"
 #include "../utils/Utils.hpp"
 
+#include <wheels/assert.hpp>
 #include <wheels/containers/array.hpp>
 #include <wheels/containers/optional.hpp>
 #include <wheels/containers/span.hpp>
@@ -276,5 +277,40 @@ class Profiler
     wheels::Array<GpuFrameProfiler::ScopeData> _previousGpuScopeData{
         gAllocators.general, sMaxScopeCount};
 };
+
+// The scope variable is never accessed so let's reduce the noise with a macro
+// zz* to push the local variable to the bottom of the locals list in debuggers
+#define PROFILER_CPU_SCOPE(profiler, name)                                     \
+    WHEELS_ASSERT(profiler != nullptr);                                        \
+    const Profiler::Scope TOKEN_APPEND(zzCpuScope, __LINE__) =                 \
+        profiler->createCpuScope(name);
+
+// The scope variable is never accessed so let's reduce the noise with a macro
+// zz* to push the local variable to the bottom of the locals list in debuggers
+#define PROFILER_GPU_SCOPE(profiler, cb, name)                                 \
+    WHEELS_ASSERT(profiler != nullptr);                                        \
+    const Profiler::Scope TOKEN_APPEND(zzGpuScope, __LINE__) =                 \
+        profiler->createGpuScope(cb, name, false);
+
+// The scope variable is never accessed so let's reduce the noise with a macro
+// zz* to push the local variable to the bottom of the locals list in debuggers
+#define PROFILER_GPU_SCOPE_WITH_STATS(profiler, cb, name)                      \
+    WHEELS_ASSERT(profiler != nullptr);                                        \
+    const Profiler::Scope TOKEN_APPEND(zzGpuScope, __LINE__) =                 \
+        profiler->createGpuScope(cb, name, true);
+
+// The scope variable is never accessed so let's reduce the noise with a macro
+// zz* to push the local variable to the bottom of the locals list in debuggers
+#define PROFILER_CPU_GPU_SCOPE(profiler, cb, name)                             \
+    WHEELS_ASSERT(profiler != nullptr);                                        \
+    const Profiler::Scope TOKEN_APPEND(zzGpuScope, __LINE__) =                 \
+        profiler->createCpuGpuScope(cb, name, false);
+
+// The scope variable is never accessed so let's reduce the noise with a macro
+// zz* to push the local variable to the bottom of the locals list in debuggers
+#define PROFILER_CPU_GPU_SCOPE_WITH_STATS(profiler, cb, name)                  \
+    WHEELS_ASSERT(profiler != nullptr);                                        \
+    const Profiler::Scope TOKEN_APPEND(zzGpuScope, __LINE__) =                 \
+        profiler->createCpuGpuScope(cb, name, true);
 
 #endif // PROSPER_UTILS_PROFILER_HPP

--- a/src/utils/Profiler.hpp
+++ b/src/utils/Profiler.hpp
@@ -143,6 +143,8 @@ class CpuFrameProfiler
     [[nodiscard]] wheels::Array<ScopeTime> getTimes(wheels::Allocator &alloc);
 
   private:
+    wheels::Array<uint32_t> _queryScopeIndices{
+        gAllocators.general, sMaxScopeCount};
     wheels::Array<std::chrono::nanoseconds> _nanos{
         gAllocators.general, sMaxScopeCount};
 
@@ -173,6 +175,11 @@ class Profiler
 
         Scope(CpuFrameProfiler::Scope &&cpuScope)
         : _cpuScope{WHEELS_MOV(cpuScope)}
+        {
+        }
+
+        Scope(GpuFrameProfiler::Scope &&gpuScope)
+        : _gpuScope{WHEELS_MOV(gpuScope)}
         {
         }
 
@@ -219,6 +226,12 @@ class Profiler
 
     // Scopes can be created between the startFrame and endFrame -calls
     [[nodiscard]] Scope createCpuScope(const char *name);
+
+    // GPU scopes shouldn't contain barriers because it might produce weird
+    // results when they block the current scope on work that belongs to the
+    // previous one.
+    [[nodiscard]] Scope createGpuScope(
+        vk::CommandBuffer cb, const char *name, bool includeStatistics = false);
 
     // GPU scopes shouldn't contain barriers because it might produce weird
     // results when they block the current scope on work that belongs to the

--- a/src/utils/Utils.hpp
+++ b/src/utils/Utils.hpp
@@ -164,4 +164,7 @@ T roundedUpQuotient(T dividend, T divisor)
     return ret;
 }
 
+#define TOKEN_APPEND_HELPER(x, y) x##y
+#define TOKEN_APPEND(x, y) TOKEN_APPEND_HELPER(x, y)
+
 #endif // PROSPER_UTILS_HPP


### PR DESCRIPTION
CPU scopes should usually span the full function and GPU scopes still seem less wrong when before barriers aren't included in them