### PR TITLE
Improve asserted_cast

### DIFF
--- a/src/App.cpp
+++ b/src/App.cpp
@@ -743,7 +743,7 @@ void App::drawProfiling(
     size_t longestNameLength = 0;
     for (const auto &t : profilerDatas)
         if (t.name.size() > longestNameLength)
-            longestNameLength = asserted_cast<size_t>(t.name.size());
+            longestNameLength = t.name.size();
 
     String tmp{scopeAlloc};
     tmp.resize(longestNameLength * 2);
@@ -859,9 +859,7 @@ void App::drawMemory(uint32_t scopeHighWatermark) const
     TlsfAllocator::Stats const &allocStats = gAllocators.general.stats();
 
     ImGui::Text("High watermarks:\n");
-    ImGui::Text(
-        "  ctors : %uKB\n",
-        asserted_cast<uint32_t>(m_ctorScratchHighWatermark) / 1024);
+    ImGui::Text("  ctors : %uKB\n", m_ctorScratchHighWatermark / 1024);
     ImGui::Text(
         "  deferred general: %uMB\n",
         asserted_cast<uint32_t>(

--- a/src/render/Renderer.cpp
+++ b/src/render/Renderer.cpp
@@ -776,10 +776,10 @@ ImageHandle Renderer::blitColorToFinalComposite(
         },
         vk::Offset3D{
             std::min(
-                asserted_cast<int32_t>(dstOffset.x + dstSize.x),
+                dstOffset.x + dstSize.x,
                 asserted_cast<int32_t>(swapImageExtent.width)),
             std::min(
-                asserted_cast<int32_t>(dstOffset.y + dstSize.y),
+                dstOffset.y + dstSize.y,
                 asserted_cast<int32_t>(swapImageExtent.height)),
             1,
         },

--- a/src/scene/Texture.cpp
+++ b/src/scene/Texture.cpp
@@ -415,8 +415,8 @@ void Texture2D::init(
     WHEELS_ASSERT(!dds.data.empty());
 
     const vk::Extent2D extent{
-        asserted_cast<uint32_t>(dds.width),
-        asserted_cast<uint32_t>(dds.height),
+        dds.width,
+        dds.height,
     };
 
     WHEELS_ASSERT(stagingBuffer.mapped != nullptr);
@@ -461,7 +461,7 @@ void Texture2D::init(
             .imageSubresource =
                 vk::ImageSubresourceLayers{
                     .aspectMask = vk::ImageAspectFlagBits::eColor,
-                    .mipLevel = asserted_cast<uint32_t>(i),
+                    .mipLevel = i,
                     .baseArrayLayer = 0,
                     .layerCount = 1,
                 },
@@ -500,9 +500,9 @@ void Texture3D::init(
     WHEELS_ASSERT(!dds.data.empty());
 
     const vk::Extent3D extent{
-        asserted_cast<uint32_t>(dds.width),
-        asserted_cast<uint32_t>(dds.height),
-        asserted_cast<uint32_t>(dds.depth),
+        dds.width,
+        dds.height,
+        dds.depth,
     };
 
     // Just create the staging here as Texture3D are only loaded in during load
@@ -600,8 +600,8 @@ void TextureCubemap::init(
         .desc =
             ImageDescription{
                 .format = cube.format,
-                .width = asserted_cast<uint32_t>(cube.width),
-                .height = asserted_cast<uint32_t>(cube.height),
+                .width = cube.width,
+                .height = cube.height,
                 .mipCount = cube.mipLevelCount,
                 .layerCount = cube.faceCount,
                 .createFlags = vk::ImageCreateFlagBits::eCubeCompatible,

--- a/src/scene/WorldData.cpp
+++ b/src/scene/WorldData.cpp
@@ -1405,9 +1405,7 @@ void WorldData::gatherScene(
             {
                 const uint32_t childIndex = sceneNode.firstChild + i;
                 scene.nodes[childIndex].parent = indices.sceneNode;
-                nodeStack.emplace_back(
-                    asserted_cast<uint32_t>(tmpNode.children[i]),
-                    asserted_cast<uint32_t>(childIndex));
+                nodeStack.emplace_back(tmpNode.children[i], childIndex);
 
                 scene.fullNodeNames.emplace_back(
                     gAllocators.general, sceneNode.fullName);


### PR DESCRIPTION
Don't allow casts into the same type because it's redundant and adds extra debug runtime cost. Requires gives nicer errors and the same ones in all build types.