### PR TITLE
Make hierarchical depth culling conservative

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -21,6 +21,19 @@
       "*.rmiss"
     ]
   },
+  "file_scan_exclusions": [
+    "**/ext",
+    "**/build",
+    "**/build-analysis",
+    "**/.git",
+    "**/.svn",
+    "**/.hg",
+    "**/CVS",
+    "**/.DS_Store",
+    "**/Thumbs.db",
+    "**/.classpath",
+    "**/.settings"
+  ],
   "languages": {
     "C++": {
       "format_on_save": "on",

--- a/res/shader/draw_list_culler.comp
+++ b/res/shader/draw_list_culler.comp
@@ -53,6 +53,8 @@ layout(set = STORAGE_SET, binding = 5) uniform sampler depthSampler;
 
 layout(push_constant) uniform DrawListCullerPC
 {
+    uvec2 hizResolution;
+    vec2 hizUvScale;
     // 0 means no hiz bound
     uint hizMipCount;
     uint outputSecondPhaseInput;
@@ -126,27 +128,12 @@ bool isSphereOccluded(MeshletBounds bounds)
         return false;
     vec2 aabbDiagonalPx = aabbScreen.zw - aabbScreen.xy;
     aabbDiagonalPx *= camera.resolution;
-    float pxRadius = length(aabbDiagonalPx);
+    float pxDiameter = length(aabbDiagonalPx);
 
     // Sample from the first mip where the whole sphere will fit a 2x2 texel
     // area. floor without + 1 as hiz mip 0 is depth mip 1. clamp to 0 as < 1
     // radii would be negative.
-    uint hizMip = uint(max(floor(log2(pxRadius)), 0));
-    if (hizMip >= PC.hizMipCount)
-        return false;
-
-    // Figure out what uv to sample hiz from
-    vec4 centerClipPos = camera.cameraToClip * centerInView;
-    centerClipPos.xyz /= centerClipPos.w;
-
-    vec2 uv = centerClipPos.xy * .5 + .5;
-    // Pick the closest 2x2 set of texels around the sample for gather
-    uv *= camera.resolution;
-    uv -= .5;
-    uv = floor(uv);
-    uv /= camera.resolution;
-    // Sampler should clamp to a border of 1 so that out of bounds samples don't
-    // get incorrectly culled
+    uint hizMip = uint(max(floor(log2(pxDiameter)), 0));
 
     // Figure out the closest depth on the bounds for conservative culling
     // TODO:
@@ -156,6 +143,35 @@ bool isSphereOccluded(MeshletBounds bounds)
     vec4 closestClipPos =
         camera.cameraToClip * camera.worldToCamera * vec4(closestWorldPos, 1);
     float closestDepth = closestClipPos.z / closestClipPos.w;
+
+    if (hizMip >= PC.hizMipCount - 1)
+    {
+        float hizDepth =
+            texture(
+                sampler2D(
+                    inHierarchicalDepth[nonuniformEXT(PC.hizMipCount - 1)],
+                    depthSampler),
+                vec2(0))
+                .r;
+        return closestDepth < hizDepth;
+    }
+    uvec2 mipResolution = PC.hizResolution >> hizMip;
+
+    // Figure out what uv to sample hiz from
+    vec4 centerClipPos = camera.cameraToClip * centerInView;
+    centerClipPos.xyz /= centerClipPos.w;
+
+    vec2 uv = centerClipPos.xy * .5 + .5;
+    // HiZ is rounded up to the next power of 2 so we need to fix up the uv
+    uv *= PC.hizUvScale;
+    // Pick the closest 2x2 set of texels around the sample for gather
+    uv *= mipResolution;
+    uv -= .5;
+    uv = floor(uv);
+    uv += .5;
+    uv /= mipResolution;
+    // Sampler should clamp to a border of 1 so that out of bounds samples don't
+    // get incorrectly culled
 
     // Gather the neighborhood around the sample point
     // Let's not worry about the cases when the whole bounds are guaranteed to

--- a/res/shader/hiz_downsampler.comp
+++ b/res/shader/hiz_downsampler.comp
@@ -17,6 +17,7 @@ spdGlobalAtomic;
 
 layout(push_constant) uniform ReducePC
 {
+    ivec2 inputResolution;
     ivec2 topMipResolution;
     uint numWorkGroupsPerSlice;
     uint mips;
@@ -33,7 +34,7 @@ shared AU1 spdCounter;
 AF4 SpdLoadSourceImage(ASU2 p, AU1 slice)
 {
     // Clamp to edge
-    p = min(p, PC.topMipResolution - 1);
+    p = min(p, PC.inputResolution - 1);
 
     // TODO:
     // Single fetch per pixel feels excessive instead of 4 texel gather. Does

--- a/res/shader/texture_debug.comp
+++ b/res/shader/texture_debug.comp
@@ -193,8 +193,17 @@ void main()
         sampleUv /= inRes();
 
         if (all(equal(outCoord, ivec2(0, 0))))
-            outPeekColor.color = textureLod(
-                sampler2D(inColor, nearestSampler), sampleUv, float(PC.lod));
+        {
+            if (all(greaterThanEqual(sampleUv, vec2(0))) &&
+                all(lessThanEqual(sampleUv, vec2(1))))
+            {
+                outPeekColor.color = textureLod(
+                    sampler2D(inColor, nearestSampler), sampleUv,
+                    float(PC.lod));
+            }
+            else
+                outPeekColor.color = vec4(1.0 / 0.0);
+        }
 
         // Snap cursor in output resolution to tie it to the correct texel
         // visually

--- a/res/shader/texture_debug.comp
+++ b/res/shader/texture_debug.comp
@@ -37,24 +37,22 @@ ivec2 inRes() { return max(PC.inRes / (1 << PC.lod), ivec2(1)); }
 
 vec2 aspectCorrectedUv(vec2 uv)
 {
-    vec2 outCoord = uv * PC.outRes;
-    float inAspectRatio = float(inRes().x) / float(inRes().y);
-    float outAspectRatio = float(PC.outRes.x) / float(PC.outRes.y);
-    if (!any(equal(inRes(), PC.outRes)))
+    if (any(notEqual(inRes(), PC.outRes)))
     {
+        vec2 outCoord = uv * PC.outRes;
+        float inAspectRatio = float(inRes().x) / float(inRes().y);
+        float outAspectRatio = float(PC.outRes.x) / float(PC.outRes.y);
         if (inAspectRatio > outAspectRatio)
         {
-            // Scale limited by height
-            float scaledHeight = PC.outRes.x / inAspectRatio;
-            float bottomRow = (PC.outRes.y - scaledHeight) / 2;
-            uv.y = (outCoord.y - bottomRow) / scaledHeight;
+            float scale = inAspectRatio / outAspectRatio;
+            uv.y *= scale;
+            uv.y -= (scale - 1) * .5;
         }
         else
         {
-            // Scale limited by width
-            float scaledWidth = PC.outRes.y * inAspectRatio;
-            float leftColumn = (PC.outRes.x - scaledWidth) / 2;
-            uv.x = (outCoord.x - leftColumn) / scaledWidth;
+            float scale = outAspectRatio / inAspectRatio;
+            uv.x *= scale;
+            uv.x -= (scale - 1) * .5;
         }
     }
     return uv;
@@ -62,28 +60,21 @@ vec2 aspectCorrectedUv(vec2 uv)
 
 vec2 unAspectCorrectedUv(vec2 uv)
 {
-    ivec2 outCoord = ivec2(uv * PC.outRes + .5);
-    float inAspectRatio = float(inRes().x) / float(inRes().y);
-    float outAspectRatio = float(PC.outRes.x) / float(PC.outRes.y);
-    if (!any(equal(inRes(), PC.outRes)))
+    if (any(notEqual(inRes(), PC.outRes)))
     {
+        float inAspectRatio = float(inRes().x) / float(inRes().y);
+        float outAspectRatio = float(PC.outRes.x) / float(PC.outRes.y);
         if (inAspectRatio > outAspectRatio)
         {
-            // Scale limited by height
-            float scaledHeight = PC.outRes.x / inAspectRatio;
-            float bottomRow = (PC.outRes.y - scaledHeight) / 2;
-            // 1.8 is a hack here but result lines up better than with 2
-            float offset = (bottomRow * 1.8) / scaledHeight;
-            uv.y -= (uv.y - .5) * offset;
+            float scale = inAspectRatio / outAspectRatio;
+            uv.y += (scale - 1) * .5;
+            uv.y /= scale;
         }
         else
         {
-            // Scale limited by width
-            float scaledWidth = PC.outRes.y * inAspectRatio;
-            float leftColumn = (PC.outRes.x - scaledWidth) / 2;
-            // 1.8 is a hack here but result lines up better than with 2
-            float offset = (leftColumn * 1.8) / scaledWidth;
-            uv.x -= (uv.x - .5) * offset;
+            float scale = outAspectRatio / inAspectRatio;
+            uv.x += (scale - 1) * .5;
+            uv.x /= scale;
         }
     }
     return uv;
@@ -145,13 +136,15 @@ void main()
     vec2 outUv = (vec2(outCoord) + .5) / vec2(PC.outRes);
     vec2 uv = aspectCorrectedUv(outUv);
 
-    // Have most of the magnifier math happen relative to the output resolution
-    float outInRatio = float(PC.outRes.x) / float(inRes().x);
-    if (flagZoom())
-        outInRatio *= 4;
+    // TODO:
+    // The magnifier doesn't line up when the cursor is near the edges
+    // TODO: This should take both x and y scales into account?
+    // float outInRatio = float(PC.outRes.x) / float(inRes().x);
+    // if (flagZoom())
+    //     outInRatio *= 4;
 
-    if (flagMagnifier() && outInRatio < MAGNIFIER_PX_DIM)
-        uv = magnifierUv(uv);
+    // if (flagMagnifier() && outInRatio < MAGNIFIER_PX_DIM)
+    //     uv = magnifierUv(uv);
 
     if (flagZoom())
         uv = zoom4xUv(uv);

--- a/res/shader/texture_debug.comp
+++ b/res/shader/texture_debug.comp
@@ -188,14 +188,14 @@ void main()
         if (all(equal(outCoord, ivec2(0, 0))))
         {
             if (all(greaterThanEqual(sampleUv, vec2(0))) &&
-                all(lessThanEqual(sampleUv, vec2(1))))
+                all(lessThan(sampleUv, vec2(1))))
             {
                 outPeekColor.color = textureLod(
                     sampler2D(inColor, nearestSampler), sampleUv,
                     float(PC.lod));
             }
             else
-                outPeekColor.color = vec4(1.0 / 0.0);
+                outPeekColor.color = vec4(1.0 / 0.0); // inf
         }
 
         // Snap cursor in output resolution to tie it to the correct texel

--- a/res/shader/texture_debug.comp
+++ b/res/shader/texture_debug.comp
@@ -33,7 +33,7 @@ bool flagMagnifier() { return bitfieldExtract(PC.flags, 5, 1) == 1; }
 vec2 zoom4xUv(vec2 uv) { return uv * .25 + .375; }
 vec2 unzoom4xUv(vec2 uv) { return (uv - .375) * 4.; }
 
-ivec2 inRes() { return PC.inRes / (1 << PC.lod); }
+ivec2 inRes() { return max(PC.inRes / (1 << PC.lod), ivec2(1)); }
 
 vec2 aspectCorrectedUv(vec2 uv)
 {

--- a/src/render/ForwardRenderer.cpp
+++ b/src/render/ForwardRenderer.cpp
@@ -120,6 +120,8 @@ ForwardRenderer::OpaqueOutput ForwardRenderer::recordOpaque(
 {
     WHEELS_ASSERT(m_initialized);
 
+    PROFILER_CPU_GPU_SCOPE(cb, "Opaque");
+
     OpaqueOutput ret;
     ret.illumination = createIllumination(renderArea.extent, "illumination");
     ret.velocity = createVelocity(renderArea.extent, "velocity");
@@ -159,7 +161,7 @@ ForwardRenderer::OpaqueOutput ForwardRenderer::recordOpaque(
             .ibl = applyIbl,
             .drawType = drawType,
         },
-        drawStats, "OpaqueGeometryFirstPhase");
+        drawStats, "  FirstPhase");
 
     gRenderResources.buffers->release(firstPhaseCullingOutput.dataBuffer);
     gRenderResources.buffers->release(firstPhaseCullingOutput.argumentBuffer);
@@ -202,7 +204,7 @@ ForwardRenderer::OpaqueOutput ForwardRenderer::recordOpaque(
                 .secondPhase = true,
                 .drawType = drawType,
             },
-            drawStats, "OpaqueGeometrySecondPhase");
+            drawStats, "  SecondPhase");
 
         gRenderResources.buffers->release(secondPhaseCullingOutput.dataBuffer);
         gRenderResources.buffers->release(
@@ -226,6 +228,8 @@ void ForwardRenderer::recordTransparent(
 {
     WHEELS_ASSERT(m_initialized);
 
+    PROFILER_CPU_GPU_SCOPE(cb, "Transparent");
+
     const MeshletCullerFirstPhaseOutput cullerOutput =
         meshletCuller->recordFirstPhase(
             scopeAlloc.child_scope(), cb, MeshletCuller::Mode::Transparent,
@@ -246,7 +250,7 @@ void ForwardRenderer::recordTransparent(
             .transparents = true,
             .drawType = drawType,
         },
-        drawStats, "TransparentGeometry");
+        drawStats, "  Geometry");
 
     gRenderResources.buffers->release(cullerOutput.dataBuffer);
     gRenderResources.buffers->release(cullerOutput.argumentBuffer);

--- a/src/render/GBufferRenderer.cpp
+++ b/src/render/GBufferRenderer.cpp
@@ -116,7 +116,7 @@ GBufferRendererOutput GBufferRenderer::record(
     WHEELS_ASSERT(m_initialized);
     WHEELS_ASSERT(drawStats != nullptr);
 
-    PROFILER_CPU_SCOPE("GBuffer");
+    PROFILER_CPU_GPU_SCOPE(cb, "GBuffer");
 
     GBufferRendererOutput ret;
     {
@@ -446,8 +446,7 @@ void GBufferRenderer::recordDraw(
     const vk::DescriptorSet ds =
         m_meshSets[nextFrame * 2 + (isSecondPhase ? 1u : 0u)];
 
-    const char *debugName =
-        isSecondPhase ? "GBufferSecondPass" : "GBufferFirstPass";
+    const char *debugName = isSecondPhase ? "  SecondPhase" : "  FirstPhase";
 
     updateDescriptorSet(
         scopeAlloc.child_scope(), ds,

--- a/src/render/HierarchicalDepthDownsampler.cpp
+++ b/src/render/HierarchicalDepthDownsampler.cpp
@@ -119,7 +119,7 @@ ImageHandle HierarchicalDepthDownsampler::record(
     const uint32_t hizMip0Width = std::bit_ceil(inDepth.extent.width) / 2;
     const uint32_t hizMip0Height = std::bit_ceil(inDepth.extent.height) / 2;
     const uint32_t hizMipCount =
-        32 - std::countl_zero(std::max(hizMip0Width, hizMip0Height));
+        getMipCount(std::max(hizMip0Width, hizMip0Height));
     WHEELS_ASSERT(hizMipCount <= sMaxMips);
 
     uvec2 dispatchThreadGroupCountXY{};

--- a/src/render/HierarchicalDepthDownsampler.cpp
+++ b/src/render/HierarchicalDepthDownsampler.cpp
@@ -99,11 +99,7 @@ ImageHandle HierarchicalDepthDownsampler::record(
 {
     WHEELS_ASSERT(m_initialized);
 
-    String passName{scopeAlloc};
-    passName.extend(debugPrefix);
-    passName.extend("HiZDownsampler");
-
-    PROFILER_CPU_SCOPE(passName.c_str());
+    PROFILER_CPU_SCOPE("  HiZDownsampler");
 
     const Image &inDepth = gRenderResources.images->resource(inNonLinearDepth);
     WHEELS_ASSERT(
@@ -209,7 +205,7 @@ ImageHandle HierarchicalDepthDownsampler::record(
         m_counterNotCleared = false;
     }
 
-    PROFILER_GPU_SCOPE(cb, passName.c_str());
+    PROFILER_GPU_SCOPE(cb, "  HiZDownsampler");
 
     const vk::DescriptorSet descriptorSet = m_computePass.storageSet(nextFrame);
 

--- a/src/render/MeshletCuller.cpp
+++ b/src/render/MeshletCuller.cpp
@@ -219,11 +219,7 @@ MeshletCullerFirstPhaseOutput MeshletCuller::recordFirstPhase(
 {
     WHEELS_ASSERT(m_initialized);
 
-    String scopeName{scopeAlloc};
-    scopeName.extend(debugPrefix);
-    scopeName.extend("DrawListFirstPhase");
-
-    PROFILER_CPU_GPU_SCOPE(cb, scopeName.c_str());
+    PROFILER_CPU_GPU_SCOPE(cb, "  DrawListFirstPhase");
 
     const BufferHandle initialList = recordGenerateList(
         scopeAlloc.child_scope(), cb, mode, world, nextFrame, debugPrefix,
@@ -261,11 +257,7 @@ MeshletCullerSecondPhaseOutput MeshletCuller::recordSecondPhase(
 {
     WHEELS_ASSERT(m_initialized);
 
-    String scopeName{scopeAlloc};
-    scopeName.extend(debugPrefix);
-    scopeName.extend("DrawListSecondPhase");
-
-    PROFILER_CPU_GPU_SCOPE(cb, scopeName.c_str());
+    PROFILER_CPU_GPU_SCOPE(cb, "  DrawListSecondPhase")
 
     String argsPrefix{scopeAlloc};
     argsPrefix.extend(debugPrefix);

--- a/src/render/dof/DepthOfFieldSetup.cpp
+++ b/src/render/dof/DepthOfFieldSetup.cpp
@@ -88,9 +88,7 @@ DepthOfFieldSetup::Output DepthOfFieldSetup::record(
             getRoundedUpHalfExtent2D(input.illumination);
 
         const uint32_t mipCount =
-            static_cast<uint32_t>(floor(log2(static_cast<float>(
-                std::max(renderExtent.width, renderExtent.height))))) +
-            1;
+            getMipCount(std::max(renderExtent.width, renderExtent.height));
         ret.halfResIllumination = gRenderResources.images->create(
             ImageDescription{
                 .format = sIlluminationFormat,

--- a/src/scene/Camera.cpp
+++ b/src/scene/Camera.cpp
@@ -237,6 +237,8 @@ const CameraParameters &Camera::parameters() const
 
 const mat4 &Camera::clipToCamera() const { return m_clipToCamera; }
 
+const uvec2 &Camera::resolution() const { return m_resolution; }
+
 bool Camera::changedThisFrame() const
 {
     WHEELS_ASSERT(m_initialized);

--- a/src/scene/Camera.hpp
+++ b/src/scene/Camera.hpp
@@ -108,6 +108,7 @@ class Camera
     [[nodiscard]] const CameraTransform &transform() const;
     [[nodiscard]] const CameraParameters &parameters() const;
     [[nodiscard]] const glm::mat4 &clipToCamera() const;
+    [[nodiscard]] const glm::uvec2 &resolution() const;
 
     [[nodiscard]] static float sensorWidth() { return 0.035f; }
 

--- a/src/scene/Texture.cpp
+++ b/src/scene/Texture.cpp
@@ -214,9 +214,8 @@ void compress(
     // First calculate mip count down to 1x1
     const int32_t fullMipLevelCount =
         options.generateMipMaps
-            ? asserted_cast<int32_t>(floor(
-                  log2(std::max(pixels.extent.width, pixels.extent.height)))) +
-                  1
+            ? asserted_cast<int32_t>(getMipCount(
+                  std::max(pixels.extent.width, pixels.extent.height)))
             : 1;
     // Truncate to 4x4 for the final level
     const uint32_t mipLevelCount =

--- a/src/scene/WorldData.cpp
+++ b/src/scene/WorldData.cpp
@@ -354,9 +354,7 @@ void WorldData::init(
     }
 
     const uint32_t radianceMips =
-        asserted_cast<uint32_t>(floor(std::log2((
-            static_cast<float>(SkyboxResources::sSkyboxRadianceResolution))))) +
-        1;
+        getMipCount(SkyboxResources::sSkyboxRadianceResolution);
     m_skyboxResources.radiance = gDevice.createImage(ImageCreateInfo{
         .desc =
             ImageDescription{

--- a/src/utils/Utils.hpp
+++ b/src/utils/Utils.hpp
@@ -141,6 +141,12 @@ inline void appendEnumVariantsAsDefines(
     }
 }
 
+inline uint32_t getMipCount(uint32_t maxDimension)
+{
+    WHEELS_ASSERT(maxDimension > 0);
+    return 32 - std::countl_zero(maxDimension - 1) + 1;
+}
+
 // Completes the division by rounding up to the next integer when there is a
 // remainder. Assumes both inputs are positive. Returns 0 when dividend is 0.
 template <typename T>


### PR DESCRIPTION
Non-power of two rendering resolution is tricky, but we can get around that by generating a proper power-of-two mip chain from it. Also fix some texture debug view mishaps.